### PR TITLE
SYS-1661: Add basic API info

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,18 @@ docker compose exec db mysql -D archivesspace -u as -pas123 -e 'select count(*) 
 ## Rebuilding Solr Index
 
 TBD - all I know for now is this is a long-running process (14 hours so far....)
+
+## Using APIs
+
+All API access is handled by the main application service, `archivesspace`, on port 8089.  This can be reached from the python container.
+`curl` example, for now:
+```
+# Open bash session on python container
+docker compose run python bash
+
+# Authenticate
+curl -s -F password="admin" "http://archivesspace:8089/users/admin/login"
+
+# Use the session key for all other API requests
+curl -H "X-ArchivesSpace-Session: your_session_key" "http://archivesspace:8089/repositories"
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,11 @@ services:
     # see README.md for more information
     image: archivesspace-local
     ports:
-      - "8080:8080"
-      - "8081:8081"
-      - "8082:8082"
-      - "8089:8089"
-      - "8090:8090"
+      - "8080:8080" # staff ui
+      - "8081:8081" # public ui
+      - "8082:8082" # oai-pmh
+      - "8089:8089" # backend (API)
+      - "8090:8090" # solr admin, allegedly - no response
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Implements [SYS-1661](https://uclalibrary.atlassian.net/browse/SYS-1661).

No code changes.  I added comments to the ports exposed by the `archivesspace` service in `docker-compose.yml`, and basic (`curl`) API access info to `README.md`.

Testing: Please confirm this info is correct.


[SYS-1661]: https://uclalibrary.atlassian.net/browse/SYS-1661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ