### PR TITLE
SYS-1666: script to delete unlinked top containers

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -18,8 +18,9 @@ USER aspace
 # Copy the rest of the application code to the working directory with aspace as the owner
 COPY --chown=aspace:aspace . .
 
-# Move the .archivessnake.yml file to the home directory
-RUN mv .archivessnake.yml /home/aspace
+# Create a link to the archivessnake config file in the home directory,
+# allowing live editing via the python/app copy, which is mounted in docker-compose.yml.
+RUN (cd .. && ln -s app/.archivessnake.yml)
 
 # Install the Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt

--- a/python/delete_unlinked_top_containers.py
+++ b/python/delete_unlinked_top_containers.py
@@ -39,7 +39,12 @@ def delete_unlinked_top_containers(container_list_file: str):
         if container_is_unlinked(container):
             logger.info(f"Deleting unlinked top container: {container}")
             delete_response = client.delete(container)
-            if delete_response.status_code == 403:
+            status_code = delete_response.status_code
+            if status_code == 200:
+                # All OK
+                deleted_count += 1
+            elif status_code == 403:
+                # Forbidden
                 logger.error(
                     f"Permission denied deleting top container {container}:"
                     f"{delete_response.json()}"
@@ -47,7 +52,12 @@ def delete_unlinked_top_containers(container_list_file: str):
                 raise PermissionError(
                     f"Permission denied deleting top container {container}"
                 )
-            deleted_count += 1
+            else:
+                # Unknown error
+                logger.error(
+                    f"Unknown error {status_code} deleting top container {container}:"
+                    f"{delete_response.json()}"
+                )
         else:
             logger.info(
                 f"Top container {container} is linked to a collection. Skipping deletion."

--- a/python/delete_unlinked_top_containers.py
+++ b/python/delete_unlinked_top_containers.py
@@ -1,0 +1,62 @@
+import asnake.logging as logging
+from asnake.client import ASnakeClient
+import argparse
+
+logging.setup_logging(filename="archivessnake.log", level="INFO")
+# set label for custom logger - all output will be in archivessnake.log
+logger = logging.get_logger("delete_unlinked_top_containers")
+client = ASnakeClient()
+
+
+def container_is_unlinked(top_container_uri: str) -> bool:
+    top_container = client.get(top_container_uri).json()
+    if len(top_container["collection"]) == 0:
+        return True
+    return False
+
+
+def container_exists(top_container_uri: str) -> bool:
+    top_container = client.get(top_container_uri).json()
+    if "error" in top_container.keys():
+        logger.error(
+            f"Error retrieving top container {top_container_uri}: {top_container['error']}"
+        )
+        return False
+    return True
+
+
+def delete_unlinked_top_containers(container_list_file: str):
+    logger.info(f"Reading top container URIs to delete from {container_list_file}")
+    with open(container_list_file, "r") as f:
+        container_list = f.readlines()
+    container_list = [x.strip() for x in container_list]
+
+    deleted_count = 0
+    skipped_uri_list = []
+    for container in container_list:
+        if not container_exists(container):
+            # error message already logged in container_exists()
+            skipped_uri_list.append(container)
+            continue
+        if container_is_unlinked(container):
+            logger.info(f"Deleting unlinked top container: {container}")
+            client.delete(container)
+            deleted_count += 1
+        else:
+            logger.info(
+                f"Top container {container} is linked to a collection. Skipping deletion."
+            )
+            skipped_uri_list.append(container)
+    logger.info(f"Deleted {deleted_count} top containers")
+    logger.info(f"Skipped {len(skipped_uri_list)} top containers: {skipped_uri_list}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "container_list_file",
+        help="Path to a file containing a list of top container URIs to delete",
+    )
+    args = parser.parse_args()
+
+    delete_unlinked_top_containers(args.container_list_file)


### PR DESCRIPTION
Implements [SYS-1666](https://uclalibrary.atlassian.net/browse/SYS-1666)

A script that uses ArchivesSnake to delete unlinked top containers as identified by `get_unlinked_top_containers.py`. The script takes one argument: the path to a text file containing URIs for deletion. This file is expected to be in the format output by `get_unlinked_top_containers.py` (one URI per line).

The script checks each URI to confirm existence and unlinked status of each top container. If a URI in the file is malformed (e.g. `/repositories/2/top_containers/string`), or corresponds to a top container that doesn't exist or has links, the script will log this, skip the URI, and continue through the file. 

[SYS-1666]: https://uclalibrary.atlassian.net/browse/SYS-1666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ