### PR TITLE
SYS-1693: Infrastructure updates

### DIFF
--- a/.docker-compose_archivesspace.env
+++ b/.docker-compose_archivesspace.env
@@ -8,3 +8,5 @@ APPCONFIG_PUBLIC_PROXY_URL="http://localhost:8081"
 ASPACE_DB_MIGRATE="true"
 # temporary(?) - disable Solr schema checksums
 APPCONFIG_SOLR_VERIFY_CHECKSUMS="false"
+# Allow custom reports
+APPCONFIG_ENABLE_CUSTOM_REPORTS="true"

--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,7 @@ cython_debug/
 # Exclude local secrets
 *secret*
 *password*
+alma_api_keys.py
+
+# Exclude database dumps
+*.sql.gz

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,7 @@ cython_debug/
 # Exclude logs and other output
 *.txt
 *.csv
+
+# Exclude local secrets
+*secret*
+*password*

--- a/README.md
+++ b/README.md
@@ -73,3 +73,14 @@ curl -s -F password="admin" "http://archivesspace:8089/users/admin/login"
 # Use the session key for all other API requests
 curl -H "X-ArchivesSpace-Session: your_session_key" "http://archivesspace:8089/repositories"
 ```
+
+## Connecting to remote instances (UCLA-specific)
+
+It's possible to access data "live" in the hosted test instance, from the development environment. This requires extra
+setup, because the APIs are IP-restricted and must be accessed via HTTPS/TLS.  General notes are in our [internal documentation](https://uclalibrary.atlassian.net/wiki/x/1gOWGg).  For this specific application:
+
+1. Add `127.0.0.1       uclalsc-test.lyrasistechnology.org` to your local `/etc/hosts`
+2. Create a tunnel from local machine through our jump server. Local port is arbitrary, I've used `9000`:
+
+   `ssh -NT -L 0.0.0.0:9000:uclalsc-test.lyrasistechnology.org:443 jump`
+3. Connect from local machine, or from within Docker, using `https://uclalsc-test.lyrasistechnology.org:9000/api` and appropriate credentials.

--- a/README.md
+++ b/README.md
@@ -84,3 +84,11 @@ setup, because the APIs are IP-restricted and must be accessed via HTTPS/TLS.  G
 
    `ssh -NT -L 0.0.0.0:9000:uclalsc-test.lyrasistechnology.org:443 jump`
 3. Connect from local machine, or from within Docker, using `https://uclalsc-test.lyrasistechnology.org:9000/api` and appropriate credentials.
+
+## API configuration files
+
+There is a default ArchivesSnake configuration file in `python/.archivessnake.yml`.  This supports access from the running `python` container to the running `archivesspace` container, using default (and non-secret) credentials.
+
+For other configurations, copy `python/.archivessnake.yml` to `python/.archivessnake_secret_DEV.yml` or `python/.archivessnake_secret_TEST.yml`, and edit the `baseurl`, `username`, and `password` fields as appropriate.  These files must be in the `python` directory to be available within the container.
+
+These are excluded from the repository, so contact a teammate if you need specific credentials.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,10 @@ services:
       context: ./python
     volumes:
       - ./python:/home/aspace/app
+    extra_hosts:
+      # For access to remote resources via ssh tunnel on host
+      - "host.docker.internal:host-gateway"
+      - "uclalsc-test.lyrasistechnology.org:host-gateway"
 
   archivesspace:
     container_name: as_aspace

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -3,8 +3,9 @@ FROM python:3.12-slim-bookworm
 # Set correct timezone
 RUN ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 
-# install git, required to install the alma_api_client package from github
-RUN apt-get update && apt-get install -y git
+# Install git, required to install the alma_api_client package from github.
+# Add curl as well for testing connectivity.
+RUN apt-get update && apt-get install -y git curl
 
 # Create generic user and group
 RUN useradd -c "generic app user" -d /home/aspace -s /bin/bash -m aspace
@@ -20,10 +21,6 @@ USER aspace
 
 # Copy the rest of the application code to the working directory with aspace as the owner
 COPY --chown=aspace:aspace . .
-
-# Create a link to the archivessnake config file in the home directory,
-# allowing live editing via the python/app copy, which is mounted in docker-compose.yml.
-RUN (cd .. && ln -s app/.archivessnake.yml)
 
 # Install the Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
Implements [SYS-1693](https://uclalibrary.atlassian.net/browse/SYS-1693)... but no collection-specific code is involved, because the existing `bradley` configuration file works perfectly with the Susan Sontag collection.

This PR makes some changes to the local development infrastructure:
* Adds support and documentation for connecting to the hosted test system
* Adds documentation for custom ArchivesSnake API config files
* Removes workaround to make a default custom API config file available; always be explicit, instead
* Excludes various secrets and database dumps from the repository
* Enables custom reports (added long ago but never committed)
* Adds `curl` to the `python` container for convenience when debugging connectivity

Rebuild the `python container` to pick up the changes:
`docker compose build python`

To actually test the Susan Sontag update:
Create `python/.archivessnake_secret_DEV.yml` as noted in `README.md`, then run:
```
docker compose run python python add_alma_barcodes_to_archivesspace.py \
--alma_environment sandbox \
--bib_id 9961804743606533 \
--holdings_id 22378568230006533 \
--resource_id 2361 \
--profile config.bradley \
--asnake_config .archivessnake_secret_DEV.yml
```

In my local system, and sandbox Alma, this finds 363 Alma items and 370 top containers. It adds barcodes to 363 containers and reports 2 unmatched containers... leaving 5 unaccounted for?  I see 2 duplicates in the set of containers, so I'm not sure where the other 3 went.  Once de-duping code (and maybe logging changes?) are added via @ztucker4 WIP, I'll re-examine these numbers.

