### PR TITLE
SYS-1692: Config to support LAUSD barcoding

### DIFF
--- a/python/add_alma_barcodes_to_archivesspace.py
+++ b/python/add_alma_barcodes_to_archivesspace.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
 
     # update ASpace top containers with barcodes
     for tc in matched_aspace_containers:
-        # aspace_client.post(tc["uri"], json=tc)
+        aspace_client.post(tc["uri"], json=tc)
         logger.info(f"Added barcode to top container {tc['uri']}")
 
     logger.info(f"Updated barcodes for {len(matched_aspace_containers)} top containers")

--- a/python/add_alma_barcodes_to_archivesspace.py
+++ b/python/add_alma_barcodes_to_archivesspace.py
@@ -8,9 +8,9 @@ from asnake.client import ASnakeClient
 import asnake.logging as logging
 
 
-logging_filename_base = "add_alma_barcodes_to_archivesspace"
 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-logging_filename = f"{logging_filename_base}_{timestamp}.log"
+logging_filename_base = f"add_alma_barcodes_to_archivesspace_{timestamp}"
+logging_filename = f"{logging_filename_base}.log"
 logging.setup_logging(filename=logging_filename, level="INFO")
 # set label for custom logger - all output will be in archivessnake.log
 logger = logging.get_logger("add_barcodes_to_archivesspace")
@@ -145,9 +145,7 @@ if __name__ == "__main__":
 
     # if there is any unhandled data, write it to a file
     if unhandled_data:
-        unhandled_data_filename = (
-            f"add_alma_barcodes_to_archivesspace_unhandled_{timestamp}.json"
-        )
+        unhandled_data_filename = f"unhandled_{logging_filename_base}.json"
         write_json_to_file(unhandled_data, unhandled_data_filename)
         logger.info(
             f"Unhandled data (items and top containers remaining unmatched or with duplicate keys)"

--- a/python/add_alma_barcodes_to_archivesspace.py
+++ b/python/add_alma_barcodes_to_archivesspace.py
@@ -16,15 +16,12 @@ def get_aspace_containers(aspace_client: ASnakeClient, resource_id: int) -> list
     url = f"/repositories/2/resources/{resource_id}/top_containers"
     container_refs = aspace_client.get(url).json()
     # remove duplicate refs, if any
-    # deduplicate using a set of tuples of sorted items
-    container_refs_deduped = {tuple(sorted(tc.items())) for tc in container_refs}
-    # convert strings back to dicts, then set back to list
-    container_refs_deduped = [dict(tc) for tc in container_refs_deduped]
+    container_refs_deduped = set([tc["ref"] for tc in container_refs])
 
     # the top containers endpoint returns refs, so we need to get the full container JSON
     containers = []
     for tc in container_refs_deduped:
-        tc_json = aspace_client.get(tc["ref"]).json()
+        tc_json = aspace_client.get(tc).json()
         # check that the container is linked to a published resource
         if not tc_json.get("is_linked_to_published_record"):
             logger.info(

--- a/python/add_alma_barcodes_to_archivesspace.py
+++ b/python/add_alma_barcodes_to_archivesspace.py
@@ -47,7 +47,9 @@ def get_alma_items(
             bib_id, holdings_id, {"limit": 100, "offset": offset}
         )
         offset += 100
-        alma_items.extend(current_items.get("item"))
+        # keep only item_data from each item in the list
+        for item in current_items.get("item"):
+            alma_items.append(item.get("item_data"))
     return alma_items
 
 
@@ -108,9 +110,13 @@ if __name__ == "__main__":
             tc for tc in aspace_containers if tc not in top_containers_with_barcodes
         ]
 
-    matched_aspace_containers, unmatched_alma_items, unmatched_aspace_containers = (
-        match_containers(alma_items, aspace_containers, logger)
-    )
+    (
+        matched_aspace_containers,
+        unmatched_alma_items,
+        unmatched_aspace_containers,
+        items_with_duplicate_keys,
+        tcs_with_duplicate_keys,
+    ) = match_containers(alma_items, aspace_containers, logger)
 
     # update ASpace top containers with barcodes
     for tc in matched_aspace_containers:
@@ -134,4 +140,22 @@ if __name__ == "__main__":
         )
         logger.info(
             "Unmatched ASpace top containers written to unmatched_aspace_containers.json"
+        )
+
+    if items_with_duplicate_keys:
+        logger.info(
+            f"Found {len(items_with_duplicate_keys)} Alma items with duplicate keys."
+        )
+        write_json_to_file(items_with_duplicate_keys, "items_with_duplicate_keys.json")
+        logger.info(
+            "Items with duplicate keys written to items_with_duplicate_keys.json"
+        )
+
+    if tcs_with_duplicate_keys:
+        logger.info(
+            f"Found {len(tcs_with_duplicate_keys)} ASpace top containers with duplicate keys."
+        )
+        write_json_to_file(tcs_with_duplicate_keys, "tcs_with_duplicate_keys.json")
+        logger.info(
+            "Top containers with duplicate keys written to tcs_with_duplicate_keys.json"
         )

--- a/python/config/box_description_matching.py
+++ b/python/config/box_description_matching.py
@@ -65,11 +65,14 @@ def _get_aspace_match_data(
         if (tc_indicator, tc_type) in match_data:
             if logger:
                 logger.error(
-                    f"Duplicate top container found: {tc_indicator} {tc_type} {tc.get('uri')}"
+                    f"Duplicate top container found: {tc_indicator} {tc_type} {tc.get('uri')}.",
+                    f" Existing top container: {match_data[(tc_indicator, tc_type)].get('uri')}.",
+                    " Skipping both top containers.",
                 )
-                logger.error(
-                    f"Existing top container: {match_data[(tc_indicator, tc_type)].get('uri')}"
-                )
+            # remove the duplicate
+            del match_data[(tc_indicator, tc_type)]
+            # skip this top container
+            continue
         match_data[(tc_indicator, tc_type)] = tc
     return match_data
 
@@ -100,10 +103,13 @@ def _get_alma_match_data(alma_items: list, logger: Optional[Any] = None) -> dict
             if logger:
                 logger.error(
                     f"Duplicate Alma description: {(alma_indicator, alma_container_type)}",
-                    f" for item {current_item_pid}",
+                    f" for item {current_item_pid}.",
+                    f" Previous item with this description: {previous_item_pid}.",
+                    " Skipping both items.",
                 )
-                logger.error(
-                    f"Previous item with this description: {previous_item_pid}"
-                )
+            # remove the duplicate
+            del match_data[(alma_indicator, alma_container_type)]
+            # skip this item
+            continue
         match_data[(alma_indicator, alma_container_type)] = item
     return match_data

--- a/python/config/box_description_matching.py
+++ b/python/config/box_description_matching.py
@@ -13,7 +13,7 @@ def match_containers(
         aspace_containers: list of ASpace top containers (JSON data as obtained from ASpace API)
 
     Returns:
-        tuple of lists containing two elements:
+        tuple containing two elements:
             matched_aspace_containers - list of JSON data elements with barcodes added,
             unhandled_data - dict containing:
                 unmatched_alma_items - list of unmatched items (JSON from Alma API),

--- a/python/config/box_description_matching.py
+++ b/python/config/box_description_matching.py
@@ -3,7 +3,7 @@ from typing import Optional, Any
 
 def match_containers(
     alma_items: list[dict], aspace_containers: list[dict], logger: Optional[Any] = None
-) -> tuple[list[dict], list[dict], list[dict]]:
+) -> tuple[list[dict], list[dict], list[dict], list[tuple], list[tuple]]:
     """
     Matches Alma items with ASpace top containers and adds barcodes to the matched top containers.
     Also returns lists of unmatched Alma items and ASpace top containers.
@@ -13,14 +13,20 @@ def match_containers(
         aspace_containers: list of ASpace top containers (JSON data as obtained from ASpace API)
 
     Returns:
-        tuple of lists containing 3 elements:
+        tuple of lists containing 5 elements:
             matched_aspace_containers (list of JSON data elements with barcodes added),
             unmatched_alma_items (list of JSON data elements as obtained from Alma API),
             unmatched_aspace_containers (list of JSON data elements as obtained from ASpace API)
+            items_with_duplicate_keys (list of tuples with Alma item PID, indicator, and type),
+            tcs_with_duplicate_keys (list of tuples with ASpace container URI, indicator, and type)
     """
     # get match data for Alma items and ASpace top containers
-    alma_match_data = _get_alma_match_data(alma_items)
-    aspace_match_data = _get_aspace_match_data(aspace_containers)
+    alma_match_data, items_with_duplicate_keys = _get_alma_match_data(
+        alma_items, logger
+    )
+    aspace_match_data, tcs_with_duplicate_keys = _get_aspace_match_data(
+        aspace_containers, logger
+    )
 
     # find matches by comparing keys in _match_data dictionaries
     matched_aspace_containers = []
@@ -28,13 +34,13 @@ def match_containers(
         if alma_key in aspace_match_data:
             tc = aspace_match_data[alma_key]
             # get barcode from Alma item and add it to ASpace top container
-            barcode = alma_item.get("item_data").get("barcode")
+            barcode = alma_item.get("barcode")
             tc["barcode"] = barcode
             matched_aspace_containers.append(tc)
 
             if logger:
                 logger.info(
-                    f"Matched item {alma_item.get('item_data').get('pid')} "
+                    f"Matched item {alma_item.get('pid')} "
                     f"with top container {tc.get('uri')}"
                 )
 
@@ -50,14 +56,21 @@ def match_containers(
         aspace_match_data[key] for key in unmatched_aspace_keys
     ]
 
-    return matched_aspace_containers, unmatched_alma_items, unmatched_aspace_containers
+    return (
+        matched_aspace_containers,
+        unmatched_alma_items,
+        unmatched_aspace_containers,
+        items_with_duplicate_keys,
+        tcs_with_duplicate_keys,
+    )
 
 
 def _get_aspace_match_data(
     aspace_containers: list, logger: Optional[Any] = None
-) -> dict[tuple]:
+) -> tuple[dict[tuple, list[tuple]]]:
     """Parses ASpace top container indicators and types into a dictionary."""
     match_data = {}
+    tcs_with_duplicate_keys = []
     for tc in aspace_containers:
         tc_indicator = tc.get("indicator")
         tc_type = tc.get("type")
@@ -65,24 +78,31 @@ def _get_aspace_match_data(
         if (tc_indicator, tc_type) in match_data:
             if logger:
                 logger.error(
-                    f"Duplicate top container found: {tc_indicator} {tc_type} {tc.get('uri')}.",
-                    f" Existing top container: {match_data[(tc_indicator, tc_type)].get('uri')}.",
-                    " Skipping both top containers.",
+                    f"Duplicate top container found: {tc_indicator} {tc_type} {tc.get('uri')}."
+                    f" Existing top container: {match_data[(tc_indicator, tc_type)].get('uri')}."
+                    " Skipping both top containers."
                 )
+            tcs_with_duplicate_keys.append((tc.get("uri"), tc_indicator, tc_type))
+            tcs_with_duplicate_keys.append(
+                (match_data[(tc_indicator, tc_type)].get("uri"), tc_indicator, tc_type)
+            )
             # remove the duplicate
             del match_data[(tc_indicator, tc_type)]
             # skip this top container
             continue
         match_data[(tc_indicator, tc_type)] = tc
-    return match_data
+    return match_data, tcs_with_duplicate_keys
 
 
-def _get_alma_match_data(alma_items: list, logger: Optional[Any] = None) -> dict[tuple]:
+def _get_alma_match_data(
+    alma_items: list, logger: Optional[Any] = None
+) -> tuple[dict[tuple], list[tuple]]:
     """Parses Alma item descriptions into container type and indicator,
     and normalizes the indicator by removing leading zeroes and " RESTRICTED"."""
     match_data = {}
+    items_with_duplicate_keys = []
     for item in alma_items:
-        description = item.get("item_data").get("description")
+        description = item.get("description")
         # split description into container type and indicator, e.g. "box.1"
         alma_container_type = description.split(".")[0]
         alma_indicator = description.split(".")[1]
@@ -96,22 +116,26 @@ def _get_alma_match_data(alma_items: list, logger: Optional[Any] = None) -> dict
 
         # check if this will be a duplicate key
         if (alma_indicator, alma_container_type) in match_data:
-            current_item_pid = item.get("item_data").get("pid")
-            previous_item_pid = (
-                match_data[(alma_indicator, alma_container_type)]
-                .get("item_data")
-                .get("pid")
+            current_item_pid = item.get("pid")
+            previous_item_pid = match_data[(alma_indicator, alma_container_type)].get(
+                "pid"
             )
             if logger:
                 logger.error(
-                    f"Duplicate Alma description: {(alma_indicator, alma_container_type)}",
-                    f" for item {current_item_pid}.",
-                    f" Previous item with this description: {previous_item_pid}.",
-                    " Skipping both items.",
+                    f"Duplicate Alma description: {(alma_indicator, alma_container_type)}"
+                    f" for item {current_item_pid}."
+                    f" Previous item with this description: {previous_item_pid}."
+                    " Skipping both items."
                 )
+            items_with_duplicate_keys.append(
+                (current_item_pid, alma_indicator, alma_container_type)
+            )
+            items_with_duplicate_keys.append(
+                (previous_item_pid, alma_indicator, alma_container_type)
+            )
             # remove the duplicate
             del match_data[(alma_indicator, alma_container_type)]
             # skip this item
             continue
         match_data[(alma_indicator, alma_container_type)] = item
-    return match_data
+    return match_data, items_with_duplicate_keys

--- a/python/config/box_description_matching.py
+++ b/python/config/box_description_matching.py
@@ -5,9 +5,8 @@ def match_containers(
     alma_items: list[dict], aspace_containers: list[dict], logger: Optional[Any] = None
 ) -> tuple[list[dict], list[dict], list[dict]]:
     """
-    Match Alma items with ASpace top containers. Parses Alma item descriptions into
-    container type and indicator, and compares them with ASpace top container indicators with
-    normalization (removing leading zeroes and " RESTRICTED" from Alma indicators).
+    Matches Alma items with ASpace top containers and adds barcodes to the matched top containers.
+    Also returns lists of unmatched Alma items and ASpace top containers.
 
     Args:
         alma_items: list of Alma items (JSON data as obtained from Alma API)
@@ -57,6 +56,7 @@ def match_containers(
 def _get_aspace_match_data(
     aspace_containers: list, logger: Optional[Any] = None
 ) -> dict[tuple]:
+    """Parses ASpace top container indicators and types into a dictionary."""
     match_data = {}
     for tc in aspace_containers:
         tc_indicator = tc.get("indicator")
@@ -78,6 +78,8 @@ def _get_aspace_match_data(
 
 
 def _get_alma_match_data(alma_items: list, logger: Optional[Any] = None) -> dict[tuple]:
+    """Parses Alma item descriptions into container type and indicator,
+    and normalizes the indicator by removing leading zeroes and " RESTRICTED"."""
     match_data = {}
     for item in alma_items:
         description = item.get("item_data").get("description")

--- a/python/tests/test_bradley_mapping.py
+++ b/python/tests/test_bradley_mapping.py
@@ -21,60 +21,69 @@ with open(aspace_data_path, "r") as aspace_data_file:
 class TestBradleyMapping(unittest.TestCase):
     def test_match_containers(self):
         # first item in alma_data should match first top container in aspace_data
-        alma_items = [alma_data[0]]
+        alma_items = [alma_data[0]["item_data"]]
         aspace_containers = [aspace_data[0]]
-        matched_aspace_containers, unmatched_alma_items, unmatched_aspace_containers = (
-            match_containers(alma_items, aspace_containers)
+        matched_aspace_containers, unhandled_data = match_containers(
+            alma_items, aspace_containers
         )
         self.assertEqual(len(matched_aspace_containers), 1)
-        self.assertEqual(len(unmatched_alma_items), 0)
-        self.assertEqual(len(unmatched_aspace_containers), 0)
+        self.assertEqual(len(unhandled_data["unmatched_alma_items"]), 0)
+        self.assertEqual(len(unhandled_data["unmatched_aspace_containers"]), 0)
+        self.assertEqual(len(unhandled_data["items_with_duplicate_keys"]), 0)
+        self.assertEqual(len(unhandled_data["tcs_with_duplicate_keys"]), 0)
         # test that the barcode was added to the matched top container
         self.assertEqual(
             matched_aspace_containers[0]["barcode"],
-            alma_items[0]["item_data"]["barcode"],
+            alma_items[0]["barcode"],
         )
 
     def test_match_containers_no_match(self):
         # second item in each set should not match
-        alma_items = [alma_data[1]]
+        alma_items = [alma_data[1]["item_data"]]
         aspace_containers = [aspace_data[1]]
-        matched_aspace_containers, unmatched_alma_items, unmatched_aspace_containers = (
-            match_containers(alma_items, aspace_containers)
+        matched_aspace_containers, unhandled_data = match_containers(
+            alma_items, aspace_containers
         )
         self.assertEqual(len(matched_aspace_containers), 0)
-        self.assertEqual(len(unmatched_alma_items), 1)
-        self.assertEqual(len(unmatched_aspace_containers), 1)
+        self.assertEqual(len(unhandled_data["unmatched_alma_items"]), 1)
+        self.assertEqual(len(unhandled_data["unmatched_aspace_containers"]), 1)
+        self.assertEqual(len(unhandled_data["items_with_duplicate_keys"]), 0)
+        self.assertEqual(len(unhandled_data["tcs_with_duplicate_keys"]), 0)
 
     def test_match_containers_leading_zeroes(self):
         # third item in each set should match, even though alma indicator has leading zeroes
-        alma_items = [alma_data[2]]
+        alma_items = [alma_data[2]["item_data"]]
         aspace_containers = [aspace_data[2]]
-        matched_aspace_containers, unmatched_alma_items, unmatched_aspace_containers = (
-            match_containers(alma_items, aspace_containers)
+        matched_aspace_containers, unhandled_data = match_containers(
+            alma_items, aspace_containers
         )
         self.assertEqual(len(matched_aspace_containers), 1)
-        self.assertEqual(len(unmatched_alma_items), 0)
-        self.assertEqual(len(unmatched_aspace_containers), 0)
+        self.assertEqual(len(unhandled_data["unmatched_alma_items"]), 0)
+        self.assertEqual(len(unhandled_data["unmatched_aspace_containers"]), 0)
+        self.assertEqual(len(unhandled_data["items_with_duplicate_keys"]), 0)
+        self.assertEqual(len(unhandled_data["tcs_with_duplicate_keys"]), 0)
+
         # test that the barcode was added to the matched top container
         self.assertEqual(
             matched_aspace_containers[0]["barcode"],
-            alma_items[0]["item_data"]["barcode"],
+            alma_items[0]["barcode"],
         )
 
     def test_match_containers_restricted(self):
         # fourth item in each set should match,
         # even though alma indicator has " RESTRICTED" at the end
-        alma_items = [alma_data[3]]
+        alma_items = [alma_data[3]["item_data"]]
         aspace_containers = [aspace_data[3]]
-        matched_aspace_containers, unmatched_alma_items, unmatched_aspace_containers = (
-            match_containers(alma_items, aspace_containers)
+        matched_aspace_containers, unhandled_data = match_containers(
+            alma_items, aspace_containers
         )
         self.assertEqual(len(matched_aspace_containers), 1)
-        self.assertEqual(len(unmatched_alma_items), 0)
-        self.assertEqual(len(unmatched_aspace_containers), 0)
+        self.assertEqual(len(unhandled_data["unmatched_alma_items"]), 0)
+        self.assertEqual(len(unhandled_data["unmatched_aspace_containers"]), 0)
+        self.assertEqual(len(unhandled_data["items_with_duplicate_keys"]), 0)
+        self.assertEqual(len(unhandled_data["tcs_with_duplicate_keys"]), 0)
         # test that the barcode was added to the matched top container
         self.assertEqual(
             matched_aspace_containers[0]["barcode"],
-            alma_items[0]["item_data"]["barcode"],
+            alma_items[0]["barcode"],
         )

--- a/python/tests/test_bradley_mapping.py
+++ b/python/tests/test_bradley_mapping.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import json
-from config.bradley import match_containers
+from config.box_description_matching import match_containers
 
 # Get the directory of the test file
 current_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Relates to [SYS-1692](https://uclalibrary.atlassian.net/browse/SYS-1692)

A few changes to support barcoding the LAUSD collection. 

* This collection uses the same Description mapping logic as the Tom Bradley collection. The config file for this mapping has been renamed (`bradley.py` -> `box_description_mapping.py`) and comments updated to remove Bradley references.
  * The mapping config file now checks for duplicate item descriptions in Alma data and duplicate (container type, indicator) pairs in ASpace data - i.e. objects that would create duplicate keys in the `match_data` dicts. If duplicates are found, an error message is logged and all duplicate objects are skipped. Currently, this is only reported through the log messages. I wasn't sure if the duplicate items should be added to the output "unmatched" files or maybe output in a new set of files. 
  * The previous approach of using `globals()` to access the logger within the config file was not working. I have reverted to my initial approach of passing the logger explicitly to each function in `box_description_mapping.py` that needs to write output. Logs are now somewhat more verbose as the "matched Alma item" lines are now included.
* In the main script, `get_aspace_containers()` now deduplicates the `container_refs` obtained from the API. Also, `is_linked_to_published_record` is now checked for each top container, and any non-linked containers will be logged and skipped. (As far as I can tell, this shouldn't happen - the API should only be returning linked containers.)
* The existing Bradley tests are updated to use the new config file name.

To test barcoding the LAUSD collection locally:
```
docker compose run python python add_alma_barcodes_to_archivesspace.py \
--alma_environment sandbox \
--bib_id 9969119863606533 \
--holdings_id 22531983170006533 \
--resource_id 1415 \
--profile config.box_description_matching \
--asnake_config .archivessnake_secret_DEV.yml
```

[SYS-1692]: https://uclalibrary.atlassian.net/browse/SYS-1692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ