### PR TITLE
SYS-1703: support dry runs and printed output

### DIFF
--- a/python/add_alma_barcodes_to_archivesspace.py
+++ b/python/add_alma_barcodes_to_archivesspace.py
@@ -132,7 +132,7 @@ def format_unhandled_data_for_printing(unhandled_data: dict) -> str:
     unmatched_aspace_containers_desc = [
         [
             int(tc.get("indicator")) if tc.get("indicator").isdigit() else 0,
-            f"{tc.get('indicator')} ({tc.get('uri')})",
+            f"{tc.get('type')} {tc.get('indicator')} ({tc.get('uri')})",
         ]
         for tc in unmatched_aspace_containers
     ]
@@ -146,7 +146,7 @@ def format_unhandled_data_for_printing(unhandled_data: dict) -> str:
     # get descriptions of top containers with existing barcodes, and sort them
     top_containers_with_barcodes = unhandled_data.get("top_containers_with_barcodes")
     top_containers_with_barcodes_desc = [
-        f"{tc.get('indicator')} ({tc.get('uri')})"
+        f"{tc.get('type')} {tc.get('indicator')} ({tc.get('uri')})"
         for tc in top_containers_with_barcodes
     ]
 

--- a/python/config/series_description_matching.py
+++ b/python/config/series_description_matching.py
@@ -37,7 +37,8 @@ def get_aspace_match_data(
         tc_indicator, tc_series = parse_aspace_indicator(tc_indicator_with_series)
 
         # normalize capitalization of series - all uppercase
-        tc_series = tc_series.upper()
+        if tc_series:
+            tc_series = tc_series.upper()
 
         # if series or indicator is empty, there was a problem parsing the indicator.
         # log an error, and set match_data to the URI, which will be a unique key

--- a/python/config/series_description_matching.py
+++ b/python/config/series_description_matching.py
@@ -35,6 +35,10 @@ def get_aspace_match_data(
         tc_type = tc.get("type")
         tc_indicator_with_series = tc.get("indicator")
         tc_indicator, tc_series = parse_aspace_indicator(tc_indicator_with_series)
+
+        # normalize capitalization of series - all uppercase
+        tc_series = tc_series.upper()
+
         # if series or indicator is empty, there was a problem parsing the indicator.
         # log an error, and set match_data to the URI, which will be a unique key
         # this way it won't match any Alma items, and will be reported as unhandled data
@@ -93,6 +97,9 @@ def get_alma_match_data(
         alma_series = description.split(" ")[0].split(".")[1]
         alma_type = description.split(" ")[1].split(".")[0]
         alma_indicator = description.split(" ")[1].split(".")[1]
+
+        # normalize capitalization of series - all uppercase
+        alma_series = alma_series.upper()
 
         # if indicator starts with leading zeroes, remove them
         alma_indicator = alma_indicator.lstrip("0")

--- a/python/tests/alma_data_series.json
+++ b/python/tests/alma_data_series.json
@@ -174,5 +174,93 @@
       "desc": "Persistent Deposit"
     },
     "retention_note": "Persistent Policy"
+  },
+  {
+    "pid": "23437856460006533",
+    "barcode": "F0000000257",
+    "policy": {
+      "value": "noncirc",
+      "desc": "Non-circulating"
+    },
+    "provenance": {
+      "value": ""
+    },
+    "description": "ser.D box.0001",
+    "library": {
+      "value": "SRLF",
+      "desc": "Southern Regional Library Facility"
+    },
+    "location": {
+      "value": "srar2",
+      "desc": "SRPERF"
+    },
+    "pages": "",
+    "pieces": "1",
+    "requested": "false",
+    "creation_date": "2004-05-22Z",
+    "modification_date": "2011-09-29Z",
+    "base_status": {
+      "value": "1",
+      "desc": "Item in place"
+    },
+    "awaiting_reshelving": "false",
+    "physical_material_type": {
+      "value": "OTHER",
+      "desc": "Other"
+    },
+    "po_line": "",
+    "is_magnetic": "false",
+    "arrival_date": "2004-05-23Z",
+    "year_of_issue": "",
+    "enumeration_a": "ser.C box.0025",
+    "enumeration_b": "",
+    "enumeration_c": "",
+    "enumeration_d": "",
+    "enumeration_e": "",
+    "enumeration_f": "",
+    "enumeration_g": "",
+    "enumeration_h": "",
+    "chronology_i": "",
+    "chronology_j": "",
+    "chronology_k": "",
+    "chronology_l": "",
+    "chronology_m": "",
+    "break_indicator": {
+      "value": ""
+    },
+    "pattern_type": {
+      "value": ""
+    },
+    "linking_number": "",
+    "type_of_unit": "",
+    "receiving_operator": "import",
+    "process_type": {
+      "value": ""
+    },
+    "inventory_number": "",
+    "inventory_price": "",
+    "alternative_call_number": "",
+    "alternative_call_number_type": {
+      "value": ""
+    },
+    "storage_location_id": "",
+    "public_note": "",
+    "fulfillment_note": "",
+    "internal_note_1": "VolEquiv=3.85",
+    "internal_note_2": "",
+    "internal_note_3": "ON_RESERVE: N | RESERVE_CHARGES: 0 | RECALLS_PLACED: 0 | HOLDS_PLACED: 0 | HISTORICAL_BOOKINGS: 0 | SHORT_LOAN_CHARGES: 0 | ",
+    "statistics_note_1": "*Arts Spec Coll",
+    "statistics_note_2": "",
+    "statistics_note_3": "",
+    "physical_condition": {},
+    "committed_to_retain": {
+      "value": "true",
+      "desc": "Yes"
+    },
+    "retention_reason": {
+      "value": "Persistent Deposit",
+      "desc": "Persistent Deposit"
+    },
+    "retention_note": "Persistent Policy"
   }
 ]

--- a/python/tests/aspace_data_series.json
+++ b/python/tests/aspace_data_series.json
@@ -146,5 +146,42 @@
     "is_linked_to_published_record": true,
     "display_string": "Box 1009M: Series Series 1.",
     "long_display_string": "Box 1009M, PASC--0003, RKO Radio Pictures records, Series Series 1."
+  },
+  {
+    "lock_version": 1,
+    "indicator": "1d",
+    "created_by": "admin",
+    "last_modified_by": "admin",
+    "create_time": "2018-06-05T22:36:18Z",
+    "system_mtime": "2022-09-30T22:49:41Z",
+    "user_mtime": "2018-06-05T22:36:18Z",
+    "type": "box",
+    "jsonmodel_type": "top_container",
+    "active_restrictions": [],
+    "container_locations": [],
+    "series": [
+      {
+        "ref": "/repositories/2/archival_objects/405228",
+        "identifier": "Series 1.",
+        "display_string": "Feature Films and Shorts, ca.1922-1956",
+        "level_display_string": "Series",
+        "publish": true
+      }
+    ],
+    "collection": [
+      {
+        "ref": "/repositories/2/resources/1273",
+        "identifier": "PASC--0003",
+        "display_string": "RKO Radio Pictures records"
+      }
+    ],
+    "uri": "/repositories/2/top_containers/3333",
+    "repository": {
+      "ref": "/repositories/2"
+    },
+    "restricted": false,
+    "is_linked_to_published_record": true,
+    "display_string": "Box 1009M: Series Series 1.",
+    "long_display_string": "Box 1009M, PASC--0003, RKO Radio Pictures records, Series Series 1."
   }
 ]

--- a/python/tests/test_series_mapping.py
+++ b/python/tests/test_series_mapping.py
@@ -96,3 +96,28 @@ class TestSeriesMapping(unittest.TestCase):
         self.assertEqual(len(unhandled_data["unmatched_aspace_containers"]), 2)
         self.assertEqual(len(items_with_duplicate_keys), 0)
         self.assertEqual(len(tcs_with_duplicate_keys), 0)
+
+    def test_case_insensitive_series_match(self):
+        # third item in alma_data should match fifth top container in aspace_data
+        # ser.D box.0001 = 1d
+        alma_items = [alma_data[2]]
+        aspace_containers = [aspace_data[4]]
+        alma_match_data, items_with_duplicate_keys = series_get_alma_match_data(
+            alma_items
+        )
+        aspace_match_data, tcs_with_duplicate_keys = series_get_aspace_match_data(
+            aspace_containers
+        )
+        matched_aspace_containers, unhandled_data = match_containers(
+            alma_match_data,
+            aspace_match_data,
+        )
+        self.assertEqual(len(matched_aspace_containers), 1)
+        self.assertEqual(len(unhandled_data["unmatched_alma_items"]), 0)
+        self.assertEqual(len(unhandled_data["unmatched_aspace_containers"]), 0)
+        self.assertEqual(len(items_with_duplicate_keys), 0)
+        self.assertEqual(len(tcs_with_duplicate_keys), 0)
+        self.assertEqual(
+            matched_aspace_containers[0]["barcode"],
+            alma_items[0]["barcode"],
+        )


### PR DESCRIPTION
Implements [SYS-1703](https://uclalibrary.atlassian.net/browse/SYS-1703)

To help with analyzing data problems in collections to barcode, this PR adds two new features to the script:

* A new parameter, `--dry_run`, that prevents the script from updating barcodes in ArchivesSpace. All other parts of the script continue to run as before.
* A new parameter, `--print_output`, that causes the script to print a summarized version of the `unhandled_data` output file directly to the console. Summary information about the run is also printed in addition to being included in the logs as before.
  * To support this, the new function `format_unhandled_data_for_printing()` is added to the main script, and creating summary info for printing/logs is refactored into `get_run_summary_info()`.

To test, run with the new parameters. Example for Neutra papers:
```
docker compose run --rm python python add_alma_barcodes_to_archivesspace.py \
--alma_environment sandbox \
--bib_id 9924703433606533 \
--holdings_id 22441495240006533 \
--resource_id 3 \
--profile config.box_description_matching \
--asnake_config .archivessnake_secret_DEV.yml \
--dry_run --print_output
```

Currently, the output sorting is intended to apply to collections using the `box_description_matching` config file - i.e. those without series information.

A small bug fix for `series_description_mapping.py` is also included with this PR. Series labels are normalized to ignore capitalization - e.g. "ser.P box.0011" should match "11p". A new test is added for this, run with `docker compose run python python -m unittest tests/test_series_mapping.py `

[SYS-1703]: https://uclalibrary.atlassian.net/browse/SYS-1703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ