### PR TITLE
SYS-1715: Refactor barcode script part 2

### DIFF
--- a/python/add_alma_barcodes_to_archivesspace.py
+++ b/python/add_alma_barcodes_to_archivesspace.py
@@ -322,14 +322,16 @@ def print_unhandled_data(unhandled_data: dict) -> None:
         print(f"{tc}\n")
 
 
-def get_run_summary_info(
+def print_summary_info(
     alma_items: list[dict],
     aspace_containers: list[dict],
     matched_aspace_containers: list[dict],
     unhandled_data: dict,
-) -> list[str]:
+    print_output: bool,
+) -> None:
     """
-    Returns a list of strings with summary information about the run.
+    Writes summary information about the run to the log.
+    If print_output is True, also prints the info to console.
     """
     summary_info = [
         f"Total Alma items: {len(alma_items)}",
@@ -350,7 +352,10 @@ def get_run_summary_info(
             f" {len(unhandled_data.get('tcs_with_duplicate_keys'))}"
         ),
     ]
-    return summary_info
+    for message in summary_info:
+        logger.info(message)
+        if print_output:
+            print(message)
 
 
 def main() -> None:
@@ -422,17 +427,17 @@ def main() -> None:
 
     # summary outputs: total number of items and top containers,
     # and numbers of unhanded items and top containers
-    run_summary = get_run_summary_info(
-        alma_items, aspace_containers, matched_aspace_containers, unhandled_data
+    print_summary_info(
+        alma_items,
+        aspace_containers,
+        matched_aspace_containers,
+        unhandled_data,
+        args.print_output,
     )
-    for message in run_summary:
-        logger.info(message)
 
-    # if print_output is set, print the run summary and unhandled data
-    # to the console in a readable format
+    # If print_output is set, print the unhandled data
+    # to the console in a readable format.
     if args.print_output:
-        for message in run_summary:
-            print(message)
         print()
         print_unhandled_data(unhandled_data)
 

--- a/python/add_alma_barcodes_to_archivesspace.py
+++ b/python/add_alma_barcodes_to_archivesspace.py
@@ -257,9 +257,9 @@ def write_json_to_file(data: list[dict], filename: str) -> None:
         json.dump(data, f, indent=2)
 
 
-def format_unhandled_data_for_printing(unhandled_data: dict) -> str:
+def print_unhandled_data(unhandled_data: dict) -> None:
     """
-    Formats the unhandled data dictionary for printing to the console.
+    Formats the unhandled data dictionary and prints it to the console.
     """
     # get descriptions of unmatched alma items, and sort them
     unmatched_alma_items = unhandled_data.get("unmatched_alma_items")
@@ -304,24 +304,22 @@ def format_unhandled_data_for_printing(unhandled_data: dict) -> str:
     # the format of these lists varies, so output all the data
     tcs_with_duplicate_keys = unhandled_data.get("tcs_with_duplicate_keys")
 
-    # format the data for printing
-    output = "Unhandled data:\n" "Unmatched Alma items:\n"
+    # Print the data.
+    print("Unhandled data:\n" "Unmatched Alma items:\n")
     for item in unmatched_alma_items_desc:
-        output += f"{item}\n"
-    output += "\nUnmatched ASpace top containers:\n"
+        print(f"{item}\n")
+    print("\nUnmatched ASpace top containers:\n")
     for tc in unmatched_aspace_containers_desc:
-        output += f"{tc}\n"
-    output += "\nASpace top containers with existing barcodes:\n"
+        print(f"{tc}\n")
+    print("\nASpace top containers with existing barcodes:\n")
     for tc in top_containers_with_barcodes_desc:
-        output += f"{tc}\n"
-    output += "\nAlma items with duplicate keys:\n"
+        print(f"{tc}\n")
+    print("\nAlma items with duplicate keys:\n")
     for item in items_with_duplicate_keys:
-        output += f"{item}\n"
-    output += "\nASpace top containers with duplicate keys:\n"
+        print(f"{item}\n")
+    print("\nASpace top containers with duplicate keys:\n")
     for tc in tcs_with_duplicate_keys:
-        output += f"{tc}\n"
-
-    return output
+        print(f"{tc}\n")
 
 
 def get_run_summary_info(
@@ -436,7 +434,7 @@ def main() -> None:
         for message in run_summary:
             print(message)
         print()
-        print(format_unhandled_data_for_printing(unhandled_data))
+        print_unhandled_data(unhandled_data)
 
     # if there is any unhandled data, write it to a file
     if unhandled_data:


### PR DESCRIPTION
Implements more refactoring for [SYS-1715](https://uclalibrary.atlassian.net/browse/SYS-1715).

This PR builds on work started in #14:
* `format_unhandled_data_for_printing()` now is `print_unhandled_data()`.  Instead of building a list of strings for the `main()` method to print, it just prints the same data directly to console.
* `get_run_summary_info()` now is `print_summary_info()`. It still builds a list of strings with the same info as before, but now writes those directly to log (and to console as well, if `print_output` is True) instead of returning the list to `main()` to log & print.
* `_get_alma_api_key()` now retrieves the Alma API key from the `alma_config.alma_api_key` in the YAML config file already used for ASpace/ASnake configuration info.
  * Since the config file now contains both ASpace and Alma info, the command-line argument has changed from `--asnake_config` to `--config_file`.
  * Since the Alma environment is no longer directly relevant, the `--alma_environment` command-line argument has been removed.  If it's important, I can add it to the config file as a key, read and log it as needed... but we don't do that with the ASpace environment, so the new behavior is consistent with that.

Testing:
Add the following to `.archivessnake_secret_DEV.yml` as a top-level key:
```
alma_config:
  # Alma sandbox, during development
  alma_api_key: SANDBOX KEY GOES HERE
```

Then, with the local system up and ready, run this to do a dry run of the Student Activism collection, with output printed as well as logged as relevant:
```
docker compose run python \
python add_alma_barcodes_to_archivesspace.py \
--bib_id 9935203453606533 \
--holdings_id 22534560750006533 \
--resource_id 3002 \
--use_cache \
--dry_run \
--print_output \
--profile config.indicator_type_matching \
--config_file .archivessnake_secret_DEV.yml
```

Output and logs should look the same as before.
Optionally, delete the cached `_data_*.json` files so Alma data is freshly retrieved, confirming that the Alma API key is being used.

Once this is approved and merged, I'll start refactoring the actual profile matching & related code.


[SYS-1715]: https://uclalibrary.atlassian.net/browse/SYS-1715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ