### PR TITLE
SYS-1878: Add script to count containers for each resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ Ask a teammate if you need help accessing the support server.
 
 Alternatively, you can run the script against the test instance from your local machine by setting up a tunneled connection. See the "Connecting to remote instances (UCLA only)" section below for more information. You will need to create a new API configuration file (copy of `.archivessnake.yml`), with an updated `baseurl` of `https://uclalsc-test.lyrasistechnology.org:9000/api` and other credentials as appropriate - ask a teammate if you need these.
 
+### Getting counts of containers by resource ID
+
+The Airtable data provided by LSC can be extended with counts of the containers related to each `Rec ID` using `get_container_counts.py`, in order to get a sense of which collections are largest, and thus which to prioritize for the barcoding process.
+
+The script accepts two arguments:
+1. `--file_name`: path to the CSV export of LSC's Airtable data
+2. `--config_file`: path to the YAML configuration file, which includes database credentials for the target ArchivesSpace instance
+
+With a `bash` session open in the `python` container, run `python get_container_counts.py --file_name {{PATH_TO_LSC_DATA}} --config_file {{PATH_TO_CONFIG_YAML}}`.
+
 ## Rebuilding Solr Index
 
 TBD - all I know for now is this is a long-running process (14 hours so far....)

--- a/python/get_container_counts.py
+++ b/python/get_container_counts.py
@@ -1,0 +1,69 @@
+from asnake.client import ASnakeClient
+from add_alma_barcodes_to_archivesspace import _get_container_refs_from_db
+import argparse
+import csv
+from pathlib import Path
+
+
+def main(args: argparse.Namespace) -> None:
+    """Counts the number of containers associated with a resource,
+    for each resource identified in the LSC Airtable data,
+    then appends the count to the Airtable data
+    and saves the extended data to a CSV file.
+
+    :param args: CLI arguments for this script.
+    """
+    client = ASnakeClient(config_file=args.config_file)
+
+    data_with_counts = []
+    with open(args.file_name, "r", newline="", encoding="utf-8") as file:
+        lsc_data = csv.DictReader(file)
+
+        print("Counting containers for each resource ID...")
+        for row in lsc_data:
+            if row["ArchivesSpace Rec ID"]:  # only get count for rows with Rec ID
+                try:
+                    resource_id = int(row["ArchivesSpace Rec ID"])
+                    # Counting container refs, rather than getting all container data
+                    db_settings = client.config.get("database")
+                    container_refs = (
+                        _get_container_refs_from_db(  # imported from existing script
+                            db_settings, resource_id
+                        )
+                    )
+                    row["container_count"] = len(container_refs)
+                except ValueError:
+                    print(
+                        f"{row["Identifier"]} does not have a valid Rec ID. Skipping..."
+                    )
+                    continue
+            else:  # set empty string for rows without Rec ID
+                row["container_count"] = ""
+
+            data_with_counts.append(row)
+
+    output_filename = Path(args.file_name).stem + "_with_container_counts.csv"
+    print(f"Done! Writing counts to {output_filename}...")
+    with open(output_filename, "w+", newline="", encoding="utf-8") as output_file:
+        fieldnames = data_with_counts[0].keys()
+        writer = csv.DictWriter(output_file, fieldnames)
+        writer.writeheader()
+        writer.writerows(data_with_counts)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--file_name",
+        help="CSV export of LSC Airtable data with collection identifiers.",
+        required=True,
+        type=str,
+    )
+    parser.add_argument(
+        "--config_file",
+        help="Path to config file with ASpace credentials",
+        required=True,
+    )
+    args = parser.parse_args()
+
+    main(args)

--- a/python/get_container_counts.py
+++ b/python/get_container_counts.py
@@ -5,53 +5,11 @@ import csv
 from pathlib import Path
 
 
-def main(args: argparse.Namespace) -> None:
-    """Counts the number of containers associated with a resource,
-    for each resource identified in the LSC Airtable data,
-    then appends the count to the Airtable data
-    and saves the extended data to a CSV file.
+def _get_args() -> argparse.Namespace:
+    """Returns the command-line arguments for this program.
 
-    :param args: CLI arguments for this script.
+    :return argparse.Namespace: The parsed CLI arguments.
     """
-    client = ASnakeClient(config_file=args.config_file)
-
-    data_with_counts = []
-    with open(args.file_name, "r", newline="", encoding="utf-8") as file:
-        lsc_data = csv.DictReader(file)
-
-        print("Counting containers for each resource ID...")
-        for row in lsc_data:
-            if row["ArchivesSpace Rec ID"]:  # only get count for rows with Rec ID
-                try:
-                    resource_id = int(row["ArchivesSpace Rec ID"])
-                    # Counting container refs, rather than getting all container data
-                    db_settings = client.config.get("database")
-                    container_refs = (
-                        _get_container_refs_from_db(  # imported from existing script
-                            db_settings, resource_id
-                        )
-                    )
-                    row["container_count"] = len(container_refs)
-                except ValueError:
-                    print(
-                        f"{row["Identifier"]} does not have a valid Rec ID. Skipping..."
-                    )
-                    continue
-            else:  # set empty string for rows without Rec ID
-                row["container_count"] = ""
-
-            data_with_counts.append(row)
-
-    output_filename = Path(args.file_name).stem + "_with_container_counts.csv"
-    print(f"Done! Writing counts to {output_filename}...")
-    with open(output_filename, "w+", newline="", encoding="utf-8") as output_file:
-        fieldnames = data_with_counts[0].keys()
-        writer = csv.DictWriter(output_file, fieldnames)
-        writer.writeheader()
-        writer.writerows(data_with_counts)
-
-
-if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--file_name",
@@ -64,6 +22,59 @@ if __name__ == "__main__":
         help="Path to config file with ASpace credentials",
         required=True,
     )
-    args = parser.parse_args()
 
-    main(args)
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Counts the number of containers associated with a resource,
+    for each resource identified in the LSC Airtable data,
+    then appends the count to the Airtable data
+    and saves the extended data to a CSV file.
+    """
+    args = _get_args()
+    client = ASnakeClient(config_file=args.config_file)
+    db_settings = client.config.get("database")
+
+    data_with_counts = []
+    with open(args.file_name, "r", newline="", encoding="utf-8") as file:
+        lsc_data = csv.DictReader(file)
+        total_rows = 0  # since `lsc_data` is a iterator, can't just get len()
+        rows_updated_with_counts = 0
+
+        print("Counting containers for each resource ID...")
+        for row in lsc_data:
+            if row["ArchivesSpace Rec ID"]:  # only get count for rows with Rec ID
+                try:
+                    resource_id = int(row["ArchivesSpace Rec ID"])
+                    # Counting container refs, rather than getting all container data
+                    container_refs = (
+                        _get_container_refs_from_db(  # imported from existing script
+                            db_settings, resource_id
+                        )
+                    )
+                    row["container_count"] = len(container_refs)
+                    rows_updated_with_counts += 1
+                except ValueError:
+                    print(
+                        f"{row["Identifier"]} does not have a valid Rec ID. Skipping..."
+                    )
+                    continue
+            else:  # set empty string for rows without Rec ID
+                row["container_count"] = ""
+
+            total_rows += 1
+            data_with_counts.append(row)
+    print(f"{rows_updated_with_counts} of {total_rows} rows were updated with counts.")
+
+    output_filename = Path(args.file_name).stem + "_with_container_counts.csv"
+    print(f"Writing counts to {output_filename}...")
+    with open(output_filename, "w+", newline="", encoding="utf-8") as output_file:
+        fieldnames = data_with_counts[0].keys()
+        writer = csv.DictWriter(output_file, fieldnames)
+        writer.writeheader()
+        writer.writerows(data_with_counts)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/test_container_retrieval.py
+++ b/python/tests/test_container_retrieval.py
@@ -12,21 +12,11 @@ class TestContainerRetrieval(unittest.TestCase):
     def setUpClass(cls):
         # Assumes config file with local information
         cls.aspace_client = ASnakeClient(config_file=".archivessnake_secret_DEV.yml")
-        db_settings = cls.aspace_client.config.get("database")
-        cls.mysql_client = connect(
-            host=db_settings.get("host"),
-            database=db_settings.get("database"),
-            user=db_settings.get("user"),
-            password=db_settings.get("password"),
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.mysql_client.close()
+        cls.db_settings = cls.aspace_client.config.get("database")
 
     def test_retrievals_are_identical(self):
         resource_id = 3002  # should have just a few top containers
         api_refs = _get_container_refs_from_api(self.aspace_client, resource_id)
-        db_refs = _get_container_refs_from_db(self.mysql_client, resource_id)
+        db_refs = _get_container_refs_from_db(self.db_settings, resource_id)
         # Don't check sizes as local data can change, but confirm the values are the same.
         self.assertEqual(api_refs, db_refs)

--- a/python/tests/test_container_retrieval.py
+++ b/python/tests/test_container_retrieval.py
@@ -1,6 +1,5 @@
 import unittest
 from asnake.client import ASnakeClient
-from MySQLdb import connect
 from add_alma_barcodes_to_archivesspace import (
     _get_container_refs_from_api,
     _get_container_refs_from_db,


### PR DESCRIPTION
Implements [SYS-1878](https://uclalibrary.atlassian.net/browse/SYS-1878)

### Acceptance criteria
- [x] The LSC barcoding project data from Airtable is extended with counts of containers for each identified resource.

### Description
This PR adds a script that accepts a CSV export of LSC's barcoding project data from Airtable (see Jira issue for link), then uses an existing function from the main barcoding script in this repo to count the number of containers related to each resource ID. The counts are then appended to the input data as a column and written to a new CSV.

The Jira ticket says to "obtain the number of ASpace records in each collection," which I interpreted to mean the number of containers related to each resource. I figured that will give us a good indication of which `Rec IDs` to prioritize. Please let me know if that's wrong.

#### Running the script
The script accepts two arguments:
1. `--file_name`: path to the CSV export of LSC's Airtable data
2. `--config_file`: path to the YAML configuration file, which includes database credentials for the target ArchivesSpace instance

With a `bash` session open in the `python` container, run `python get_container_counts.py --file_name {{PATH_TO_LSC_DATA}} --config_file {{PATH_TO_CONFIG_YAML}}`.

### Testing
I did not add any new unit tests, as the `_get_container_refs_from_db` from `add_alma_barcodes_to_archivesspace.py` already has a test. However, that test was failing, so I fixed an issue with it, which I describe inline in a separate comment.

[SYS-1878]: https://uclalibrary.atlassian.net/browse/SYS-1878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ