### PR TITLE
SYS-1878: Fix f-string problem under python 3.11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,24 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
-	"image": "archivesspace-toolkit-python:latest",
+	"name": "ASpace Python",
+	"dockerComposeFile": "../docker-compose.yml",
+	"service": "python",
+	"workspaceFolder": "/home/aspace/app",
 	"customizations": {
-		"vscode": {
-			"extensions": [
-				"ms-python.python",
-				"ms-python.black-formatter",
-				"ms-python.flake8"
-			]
-		}
-	},
-        "workspaceMount": "source=${localWorkspaceFolder},target=/home/aspace/app,type=bind",
-        "workspaceFolder": "/home/aspace/app"
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Uncomment the next line to run commands after the container is created.
-	// "postCreateCommand": "cat /etc/os-release",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "devcontainer"
+			"vscode": {
+					"extensions": [
+							"ms-python.python",
+							"ms-python.black-formatter",
+							"ms-python.flake8"
+					],
+					"settings": {
+							"editor.formatOnSave": true,
+							"python.analysis.typeCheckingMode": "standard",
+							"python.editor.defaultFormatter": "ms-python.black-formatter",
+					"flake8.args": [
+									"--max-line-length=100",
+									"--extend-ignore=E203"
+							]
+					}
+			}
+	}
 }

--- a/README.md
+++ b/README.md
@@ -2,21 +2,60 @@
 An environment for local development and testing of tools to update UCLA's ArchivesSpace records.
 
 ## Local Setup
-To support both AMD and ARM architectures, we need to build the main ArchivesSpace container image locally. To do this, first clone the ArchivesSpace repo: https://github.com/archivesspace/archivesspace/. Navigate to the main `archivesspace` directory and build the image, tagging it as `archivesspace-local`:
+To support both AMD and ARM architectures, we need to build the main ArchivesSpace container image locally. **Do this only when decided by team, so all developers have the same version.**
+
+To do this, first clone the ArchivesSpace repo: https://github.com/archivesspace/archivesspace/. Navigate to the main `archivesspace` directory and build the image, tagging it as `archivesspace-local`:
 
 `docker build . -t archivesspace-local`
 
-Then, navigate back to this repo's main directory (`archivesspace-toolkit`) and run the containers with `docker compose`: 
+Then, navigate back to this repo's main directory (`archivesspace-toolkit`).
 
-`docker compose up -d`
+### Dev container
 
-Wait until you see the below message in the `as_aspace` container logs:
+This project comes with a basic dev container definition, in `.devcontainer/devcontainer.json`. It's known to work with VS Code,
+and may work with other IDEs like PyCharm.  For VS Code, it also installs the Python, Black (formatter), and Flake8 (linter)
+extensions.
+
+The project's directory is available within the container at `/home/aspace/app`.
+
+### Rebuilding the dev container
+
+VS Code builds its own container from the base image. This container may not always get rebuilt when the base image is rebuilt
+(e.g., if packages are changed via `requirements.txt`).
+
+If needed, rebuild the dev container by:
+1. Close VS Code and wait several seconds for the dev container to shut down (check via `docker ps`).
+2. Delete the dev container.
+   1. `docker images | grep vsc-archivesspace-toolkit` # vsc-archivesspace-toolkit-LONG_HEX_STRING-uid
+   2. `docker image rm -f vsc-archivesspace-toolkit-LONG_HEX_STRING-uid`
+3. Start VS Code as usual.
+
+The system takes 30-60 seconds to start up.  The database should be available quickly, but ArchivesSpace is not fully up until
+you see the below message in the `as_aspace` container logs:
 ```
 Welcome to ArchivesSpace!
 You can now point your browser to http://localhost:8080
 ```
 
-The staff interface will be available at http://localhost:8080, and the public interface will be at http://localhost:8081. Log in with username and password `admin`.
+The staff interface will be available at http://localhost:8080, and the public interface will be at http://localhost:8081. Log in with username and password `admin`,
+or your own credentials if using a copy of the production database (see Loading data, below).
+
+## Running code
+
+Running code from a VS Code terminal within the dev container should just work, e.g.: `python some_script.py` (whatever the specific program is).
+
+Otherwise, run a program via docker compose.  From the project directory:
+
+```
+# Start the system
+$ docker compose up -d
+
+# Open a shell in the container
+$ docker compose exec python bash
+
+# Open a Python shell in the container
+$ docker compose exec python python
+```
 
 ## Loading Data
 
@@ -96,7 +135,7 @@ The script also takes the following optional arguments:
 
 With all containers running, run the script from the main project directory:
 ```bash
-docker compose run python python add_alma_barcodes_to_archivesspace.py \
+docker compose exec python python add_alma_barcodes_to_archivesspace.py \
     --bib_id 123456789 \
     --holdings_id 987654321 \
     --resource_id 1234 \
@@ -181,7 +220,7 @@ All API access is handled by the main application service, `archivesspace`, on p
 `curl` example, for now:
 ```
 # Open bash session on python container
-docker compose run python bash
+docker compose exec python bash
 
 # Authenticate
 curl -s -F password="admin" "http://archivesspace:8089/users/admin/login"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - "host.docker.internal:host-gateway"
       - "uclalsc-test.lyrasistechnology.org:host-gateway"
       - "uclalsc-staff.lyrasistechnology.org:host-gateway"
+    # Keep the container running until stopped via docker compose.
+    command: "sleep infinity"
 
   archivesspace:
     container_name: as_aspace

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bookworm
+FROM python:3.11-slim-bookworm
 
 # Set correct timezone
 RUN ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime

--- a/python/get_container_counts.py
+++ b/python/get_container_counts.py
@@ -57,7 +57,7 @@ def main() -> None:
                     rows_updated_with_counts += 1
                 except ValueError:
                     print(
-                        f"{row["Identifier"]} does not have a valid Rec ID. Skipping..."
+                        f'{row["Identifier"]} does not have a valid Rec ID. Skipping...'
                     )
                     continue
             else:  # set empty string for rows without Rec ID


### PR DESCRIPTION
Fixes a minor bug in `get_container_counts.py`: our server environment requires Python 3.11, which does not support f-strings with nested quotes of the same kind.  For example, `f"{row["id"]}"` works fine in Python 3.12 and later, but must be changed to `f'{row["id"]}'` in Python 3.11.

To avoid future problems like this, I downgraded the `python` container in this system to Python 3.11.  I also updated the development infrastructure to use our newer approach to dev containers based on docker compose.  That required changes to `README.md` as well.

### Testing

```
# Stop system, if needed
$ docker compose down

# Find aspace containers
$ docker images | grep archivesspace

# Drop the vscode-created dev container, if any
$ docker rmi -f vsc-archivesspace-toolkit-UNIQUE_HEX_STRING-uid

# Drop the old python container
$ docker rmi -f archivesspace-toolkit-python

# Clean up
$ docker system prune
```

Now run `code .` in the top-level project directory, Choose to "Reopen in container" and marvel as everything is (slowly...) rebuilt and started.

From your local shell, run tests:
`docker compose exec python python -m unittest`

or via vscode within the running terminal:
`python -m unittest`

Either should show 14 passing tests.
