### PR TITLE
SYS-1902: Change local database name to match production SQL dumps

### DIFF
--- a/.docker-compose_archivesspace.env
+++ b/.docker-compose_archivesspace.env
@@ -1,4 +1,4 @@
-APPCONFIG_DB_URL="jdbc:mysql://db:3306/archivesspace?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123"
+APPCONFIG_DB_URL="jdbc:mysql://db:3306/ucla?useUnicode=true&characterEncoding=UTF-8&user=as&password=as123"
 # disable the embedded solr
 APPCONFIG_ENABLE_SOLR="false"
 APPCONFIG_SOLR_URL="http://solr:8983/solr/archivesspace"

--- a/.docker-compose_db.env
+++ b/.docker-compose_db.env
@@ -1,5 +1,6 @@
 # database config
 MYSQL_ROOT_PASSWORD="123456"
-MYSQL_DATABASE="archivesspace"
+# Starting July 2025, production db dumps are named ucla, not archivesspace
+MYSQL_DATABASE="ucla"
 MYSQL_USER="as"
 MYSQL_PASSWORD="as123"

--- a/README.md
+++ b/README.md
@@ -70,15 +70,16 @@ $ docker compose exec python python -m unittest
 2. Start your local system, if not already up: `docker compose up -d`, and wait for the application to be ready.
 3. Run the following to load the data.  Since database storage is persisted via volume on the host, this will use about 2.7 GB of local storage on your computer.  This will take several minutes, depending on computer:
 ```
-gunzip -dc ucla.sql.gz | docker compose exec -T db mysql -D archivesspace -u root -p123456
+gunzip -dc ucla.sql.gz | docker compose exec -T db mysql -D ucla -u root -p123456
 
 # This unzips the database dump to STDOUT, pipes it to mysql running on the db service, loading the data
-# into the archivesspace database. The mysql user must be root; password 123456 comes from .docker-compose_db.env.
+# into the ucla database. The mysql user must be root; password 123456 and the MYSQL_DATABASE name
+# come from .docker-compose_db.env.
 ```
 4. Ignore the warning: `mysql: [Warning] Using a password on the command line interface can be insecure.`
 5. Quick verification of data load: 
 ```
-docker compose exec db mysql -D archivesspace -u as -pas123 -e 'select count(*) from repository;'
+docker compose exec db mysql -D ucla -u as -pas123 -e 'select count(*) from repository;'
 +----------+
 | count(*) |
 +----------+
@@ -97,7 +98,7 @@ After a database refresh from production, the initial local `admin/admin` accoun
 
 To set the admin password to be the same as the production password for your own user, run this after changing `YOUR_ASPACE_USERNAME` to the appropriate value:
 ```
-docker compose exec db mysql -D archivesspace -u as -pas123 \
+docker compose exec db mysql -D ucla -u as -pas123 \
 -e 'update auth_db as t1, (select * from auth_db where username = "YOUR_ASPACE_USERNAME") as t2 set t1.pwhash = t2.pwhash where t1.username = "admin";'
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
     container_name: as_solr
     build:
       context: ./solr
+    # For solr-create, -c is core name, -d is config directory
     command: solr-create -p 8983 -c archivesspace -d archivesspace
     ports:
       - "8983:8983"

--- a/python/.archivessnake.yml
+++ b/python/.archivessnake.yml
@@ -5,7 +5,7 @@ logging_config:
   default_config: DEBUG_TO_FILE
 database:
   host: db
-  database: archivesspace
+  database: ucla
   user: as
   password: as123
 alma_config:


### PR DESCRIPTION
Fixes [SYS-1902](https://uclalibrary.atlassian.net/browse/SYS-1902).

This PR fixes a problem first noticed when importing a production database dump from July 2025 into local developer environments.  These were configured to use a local MySQL database named `archivesspace`, but the production dumps now refer explicitly to a database named `ucla`.  The local application didn't know anything about this `ucla` database, so it kept using the old `archivesspace` database.

The `docker compose` files now refer to the `ucla` database, as do the examples in `README.md`.  There's also now a comment in the `solr` service definition of `docker-compose.yml`, clarifying that the arguments in `solr-create -p 8983 -c archivesspace -d archivesspace` are not database-related.

The database placeholder in `python/.archivessnake.yml` has been updated.  Developers will need to update the real value in `python/.archivessnake_secret_DEV.yml` manually, as that file is not under source control.

To confirm these changes work:
```
# Shut down system, if running
docker compose down

# Drop the old database volume, to get rid of the archivesspace database
docker volume rm archivesspace-toolkit_db

# Start the system, and wait until all containers show as Started or Healthy
# No need to wait for the browser UI, but the db service must be healthy
docker compose up -d

# Import the database, using the command from the README, including the new database name
gunzip -dc ucla.sql.gz | docker compose exec -T db mysql -D ucla -u root -p123456

# Wait.... should be no errors other than the normal warning
mysql: [Warning] Using a password on the command line interface can be insecure.

# Check there is a ucla db, but not an archivesspace db
docker compose exec db mysql -u root -p123456 -e 'show databases;'
+--------------------+
| Database           |
+--------------------+
| information_schema |
| mysql              |
| performance_schema |
| sys                |
| ucla               |
+--------------------+

# There should be 3 repositories (the default, LSC, and TEST)
docker compose exec db mysql -D ucla -u as -pas123 -e 'select count(*) from repository;'
+----------+
| count(*) |
+----------+
|        3 |
+----------+

# All 14 tests should still pass; they don't use the db but some use the ASpace API,
# so be sure to update python/.archivessnake_secret_DEV.yml first.
docker compose exec python python -m unittest
```

@ztucker4 FYI, feel free to review/test if you want, but you'll need to apply this change before starting any other ASpace work.



[SYS-1902]: https://uclalibrary.atlassian.net/browse/SYS-1902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ