### PR TITLE
DLSR-13: Update duplicate detection script to ignore backlog material

### DIFF
--- a/python/find_duplicate_indicators.py
+++ b/python/find_duplicate_indicators.py
@@ -129,6 +129,27 @@ def get_locations_from_container_uri(
     return full_locations
 
 
+def get_linked_archival_objects_from_container_uri(
+    aspace_client: ASnakeClient, container_uri: str
+) -> list[str]:
+    """Given a container URI, returns a list of titles for the archival objects
+    linked to that container.
+
+    :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
+    :param str container_uri: The URI of the container to retrieve.
+    """
+    container = aspace_client.get(container_uri).json()
+    ao_refs = container.get("series", [])
+    full_aos = []
+    if ao_refs:
+        for ao in ao_refs:
+            if "ref" in ao:
+                archival_object = aspace_client.get(ao["ref"]).json()
+                full_aos.append(archival_object.get("title", "Unknown Archival Object"))
+
+    return full_aos
+
+
 def write_duplicates_to_file(
     duplicates: list[dict], filename: str, base_url: str
 ) -> None:
@@ -253,6 +274,13 @@ def main() -> None:
         # Create a dictionary where the key is a tuple of (indicator, type)
         # and the value is a list of container URIs that have that indicator and type
         for container_ref in container_refs:
+            # Check whether this is a "backlog material" container that should be skipped
+            linked_aos = get_linked_archival_objects_from_container_uri(
+                aspace_client, container_ref
+            )
+            if any("backlog material" in ao.lower() for ao in linked_aos):
+                continue
+
             tc_indicator, tc_type = get_indicator_and_type_from_container_uri(
                 aspace_client, container_ref
             )

--- a/python/find_duplicate_indicators.py
+++ b/python/find_duplicate_indicators.py
@@ -209,6 +209,29 @@ def format_tc_uri_as_link(uri: str, base_url: str) -> str:
     return f"{base_url}/{tc_path}"
 
 
+def remove_backlog_containers_from_list(
+    aspace_client: ASnakeClient, duplicates: list, logger: BoundLogger
+) -> list[dict]:
+    """Given a list of top containers, removes any that are linked to Archival Objects
+    with "backlog material" in the title.
+
+    :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
+    :param list duplicates: A list of Top Container URIs to check.
+    :param BoundLogger logger: A logger instance for logging messages.
+    """
+    filtered_duplicates = []
+    for uri in duplicates:
+        linked_aos = get_linked_archival_objects_from_container_uri(aspace_client, uri)
+        if any("backlog material" in ao.lower() for ao in linked_aos):
+            # Log that this TC is being skipped due to backlog AO
+            logger.info(
+                f"Skipping container {uri} because it is linked to a backlog AO."
+            )
+        else:
+            filtered_duplicates.append(uri)
+    return filtered_duplicates
+
+
 def main() -> None:
     args = _get_args()
     logger = _get_logger()
@@ -274,13 +297,6 @@ def main() -> None:
         # Create a dictionary where the key is a tuple of (indicator, type)
         # and the value is a list of container URIs that have that indicator and type
         for container_ref in container_refs:
-            # Check whether this is a "backlog material" container that should be skipped
-            linked_aos = get_linked_archival_objects_from_container_uri(
-                aspace_client, container_ref
-            )
-            if any("backlog material" in ao.lower() for ao in linked_aos):
-                continue
-
             tc_indicator, tc_type = get_indicator_and_type_from_container_uri(
                 aspace_client, container_ref
             )
@@ -289,11 +305,21 @@ def main() -> None:
                 indicator_type_pairs_seen[key] = []
             indicator_type_pairs_seen[key].append(container_ref)
 
-        # After collecting all, find duplicates (i.e. keys with more than one container URI)
+        # Remove "backlog material" containers from all potential duplicates
+        for key, container_uri_list in indicator_type_pairs_seen.items():
+            if len(container_uri_list) > 1:
+                # Only check for backlog material if we have more than one container
+                # with the same indicator/type to avoid unnecessary API calls.
+                indicator_type_pairs_seen[key] = remove_backlog_containers_from_list(
+                    aspace_client, container_uri_list, logger
+                )
+
         for (
             tc_indicator,
             tc_type,
         ), container_uri_list in indicator_type_pairs_seen.items():
+            # If we still have more than one container after removing backlog containers,
+            # all of those are duplicates.
             if len(container_uri_list) > 1:
                 logger.warning(
                     f"Duplicate indicator found: {tc_type} {tc_indicator} "


### PR DESCRIPTION
Implements [DLSR-13](https://uclalibrary.atlassian.net/browse/DLSR-13)

Updates `find_duplicate_indicators.py` to address a special case noted by LSC. If a Top Container is linked to an Archival Object with "backlog material" in its title, it is not a duplicate and should be excluded.

The script now makes an additional API call for every TC with a shared indicator/type pair to check for any linked "backlog" AOs. If any are found, the TC is not considered a duplicate.

In the test ASpace database, Collection ID `828` is an example with valid, non-backlog duplicates, and `34` is an example with only backlog duplicates:

```
python find_duplicate_indicators.py --config_file .archivessnake_secret_TEST.yml --collection_id 828
python find_duplicate_indicators.py --config_file .archivessnake_secret_TEST.yml --collection_id 34
```

[DLSR-13]: https://uclalibrary.atlassian.net/browse/DLSR-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ