### PR TITLE
DLSR-11: Parse and cleanup compound indicators

### DIFF
--- a/python/add_alma_barcodes_to_archivesspace.py
+++ b/python/add_alma_barcodes_to_archivesspace.py
@@ -25,9 +25,11 @@ def _get_logger(name: str | None = None) -> BoundLogger:
     if not name:
         # Use base filename of current script.
         name = Path(__file__).stem
+    logs_dir = Path("logs")  # save logs to "./logs/"
+    logs_dir.mkdir(parents=True, exist_ok=True)  # create dir if it doesn't exist
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     logging_filename_base = f"{name}_{timestamp}"
-    logging_filename = f"{logging_filename_base}.log"
+    logging_filename = logs_dir / f"{logging_filename_base}.log"
     logging.setup_logging(filename=logging_filename, level="INFO")
     return logging.get_logger(name=name)
 

--- a/python/add_alma_barcodes_to_archivesspace.py
+++ b/python/add_alma_barcodes_to_archivesspace.py
@@ -109,7 +109,7 @@ def _get_alma_items_from_alma(
     offset = 0
     # get the total expected number of items
     total_items = alma_client.get_items(bib_id, holdings_id, {"limit": 1}).get(
-        "total_record_count"
+        "total_record_count", 0
     )
     while len(alma_items) < total_items:
         current_items = alma_client.get_items(
@@ -117,7 +117,7 @@ def _get_alma_items_from_alma(
         )
         offset += 100
         # keep only item_data from each item in the list
-        for item in current_items.get("item"):
+        for item in current_items.get("item", []):
             alma_items.append(item.get("item_data"))
     return alma_items
 
@@ -182,7 +182,7 @@ def _get_container_refs_from_db(db_settings: dict, resource_id: int) -> set[str]
 
 def _get_containers_from_container_refs(
     aspace_client: ASnakeClient, container_refs: set[str]
-) -> list[str]:
+) -> list[dict]:
     """Returns a list of container data, given a set of container refs.
 
     :param ASnakeClient aspace_client: ASnakeClient instance.
@@ -191,7 +191,7 @@ def _get_containers_from_container_refs(
     """
     containers = []
     for tc in container_refs:
-        tc_json = aspace_client.get(tc).json()
+        tc_json: dict = aspace_client.get(tc).json()
         # Check that the container is linked to a published resource.
         if not tc_json.get("is_linked_to_published_record"):
             logger.info(
@@ -203,7 +203,7 @@ def _get_containers_from_container_refs(
     return containers
 
 
-def _get_cached_data_from_file(filename: str) -> list[dict]:
+def _get_cached_data_from_file(filename: str) -> list[dict] | None:
     """Reads data from the given file and returns it.
     For this project, data will be list[dict], but this method does not enforce that.
 
@@ -261,7 +261,7 @@ def get_alma_items(
 
 def get_aspace_containers(
     aspace_client: ASnakeClient, resource_id: int, use_db: bool, use_cache: bool
-) -> list[str]:
+) -> list[dict]:
     """Given a set of top container ref URIs, obtain the full container data as JSON
     for each one that linked to a published resource.
     Returns a list of qualifying container data.
@@ -294,10 +294,10 @@ def get_aspace_containers(
     return containers
 
 
-def write_json_to_file(data: list[dict], filename: str) -> None:
+def write_json_to_file(data: dict, filename: str) -> None:
     """Utility function for writing cache files.
 
-    :param list[dict] data: A list of dicts to write to a file.
+    :param dict data: A dict to write to a file.
     :param str filename: Filename for output file.
     """
     with open(filename, "w") as f:
@@ -310,7 +310,7 @@ def print_unhandled_data(unhandled_data: dict) -> None:
     :param dict unhandled_data: A dict representing an item of unhandled data.
     """
     # get descriptions of unmatched alma items, and sort them
-    unmatched_alma_items = unhandled_data.get("unmatched_alma_items")
+    unmatched_alma_items = unhandled_data.get("unmatched_alma_items", [])
     unmatched_alma_items_desc = [
         f"{item.get('description')} ({item.get('barcode')})"
         for item in unmatched_alma_items
@@ -318,7 +318,7 @@ def print_unhandled_data(unhandled_data: dict) -> None:
     unmatched_alma_items_desc.sort()
 
     # get indicators of unmatched aspace top containers, and sort them
-    unmatched_aspace_containers = unhandled_data.get("unmatched_aspace_containers")
+    unmatched_aspace_containers = unhandled_data.get("unmatched_aspace_containers", [])
     # we'll want to sort the indicators as numbers, not strings
     # so add a sort key to the list of top containers
     # the sort key is the integer value of the indicator, or 0 if it's not a number
@@ -338,7 +338,9 @@ def print_unhandled_data(unhandled_data: dict) -> None:
     ]
 
     # get descriptions of top containers with existing barcodes, and sort them
-    top_containers_with_barcodes = unhandled_data.get("top_containers_with_barcodes")
+    top_containers_with_barcodes = unhandled_data.get(
+        "top_containers_with_barcodes", []
+    )
     top_containers_with_barcodes_desc = [
         f"{tc.get('type')} {tc.get('indicator')} ({tc.get('uri')})"
         for tc in top_containers_with_barcodes
@@ -346,11 +348,11 @@ def print_unhandled_data(unhandled_data: dict) -> None:
 
     # get descriptions of items with duplicate keys, and sort them
     # the format of these lists varies, so output all the data
-    items_with_duplicate_keys = unhandled_data.get("items_with_duplicate_keys")
+    items_with_duplicate_keys = unhandled_data.get("items_with_duplicate_keys", [])
 
     # get descriptions of top containers with duplicate keys, and sort them
     # the format of these lists varies, so output all the data
-    tcs_with_duplicate_keys = unhandled_data.get("tcs_with_duplicate_keys")
+    tcs_with_duplicate_keys = unhandled_data.get("tcs_with_duplicate_keys", [])
 
     # Print the data.
     print("Unhandled data:\n" "Unmatched Alma items:\n")
@@ -392,17 +394,20 @@ def print_summary_info(
         f"Matched ASpace top containers: {len(matched_aspace_containers)}",
         (
             f"ASpace top containers with existing barcodes:"
-            f" {len(unhandled_data.get('top_containers_with_barcodes'))}"
+            f" {len(unhandled_data.get('top_containers_with_barcodes', []))}"
         ),
-        f"Unmatched Alma items: {len(unhandled_data.get('unmatched_alma_items'))}",
+        f"Unmatched Alma items: {len(unhandled_data.get('unmatched_alma_items', []))}",
         (
             f"Unmatched ASpace top containers:"
-            f" {len(unhandled_data.get('unmatched_aspace_containers'))}"
+            f" {len(unhandled_data.get('unmatched_aspace_containers', []))}"
         ),
-        f"Alma items with duplicate keys: {len(unhandled_data.get('items_with_duplicate_keys'))}",
+        (
+            f"Alma items with duplicate keys:"
+            f" {len(unhandled_data.get('items_with_duplicate_keys', []))}"
+        ),
         (
             f"ASpace top containers with duplicate keys:"
-            f" {len(unhandled_data.get('tcs_with_duplicate_keys'))}"
+            f" {len(unhandled_data.get('tcs_with_duplicate_keys', []))}"
         ),
     ]
     for message in summary_info:

--- a/python/aspace_utils.py
+++ b/python/aspace_utils.py
@@ -89,7 +89,7 @@ def _get_ao_refs_for_top_container_from_db(
     # This adapts the query used in `_get_container_refs_from_db` to return
     # the set of archival object refs linked to the given top container.
     query = """
-        select distinct 
+        select distinct
             concat('/repositories/', r.repo_id, '/archival_objects/', ao.id) as ao_uri
         from resource r
         inner join archival_object ao on r.id = ao.root_record_id

--- a/python/aspace_utils.py
+++ b/python/aspace_utils.py
@@ -1,0 +1,111 @@
+"""
+Utility functions and helpers for working with ArchivesSpace.
+
+This module provides utility functions for interacting with ArchivesSpace
+that can be reused across multiple scripts in the toolkit.
+"""
+
+from asnake.client import ASnakeClient
+from MySQLdb import connect
+from MySQLdb.cursors import DictCursor
+
+
+def _get_container_refs_from_api(
+    aspace_client: ASnakeClient, resource_id: int
+) -> set[str]:
+    """Returns a de-duped set of _ref_ top container URIs for the given resource_id,
+    obtained via API call.
+    This API call can fail via timeout in hosted environments, when
+    more than a few thousand containers are associated with the resource.
+
+    :param ASnakeClient aspace_client: ASnakeClient instance.
+    :param int resource_id: ASpace resource ID for target collection.
+    :return: A set of container refs.
+    """
+    url = f"/repositories/2/resources/{resource_id}/top_containers"
+    container_refs = aspace_client.get(url).json()
+    # Extract the ref URIs and de-dup.
+    return set(tc["ref"] for tc in container_refs)
+
+
+def _get_container_refs_from_db(db_settings: dict, resource_id: int) -> set[str]:
+    """Returns a de-duped set of _ref_ top container URIs for the given resource_id,
+    obtained via database query.
+    This is intended as an alternative for resources with more than a few thousand
+    containers, as the API call may time out.
+
+    :param dict db_settings: A dict with DB connection details.
+    :param int resource_id: ASpace resource ID for target collection.
+    :return: A set of container refs.
+    """
+    mysql_client = connect(
+        host=db_settings.get("host"),
+        database=db_settings.get("database"),
+        user=db_settings.get("user"),
+        password=db_settings.get("password"),
+    )
+
+    query = """
+        select distinct
+            concat('/repositories/', r.repo_id, '/top_containers/', tc.id) as container_uri
+        from resource r
+        inner join archival_object ao on r.id = ao.root_record_id
+        inner join instance i on ao.id = i.archival_object_id
+        inner join sub_container sc on i.id = sc.instance_id
+        inner join top_container_link_rlshp tclr on sc.id = tclr.sub_container_id
+        inner join top_container tc on tclr.top_container_id = tc.id
+        where r.id = %s
+        and ao.publish = 1 -- true
+        and ao.suppressed = 0 -- false
+        order by container_uri
+    """
+    # Parameterized query requires tuple of values
+    cursor = mysql_client.cursor(DictCursor)
+    cursor.execute(query, (resource_id,))
+    container_refs = set(row["container_uri"] for row in cursor.fetchall())
+    cursor.close()
+    mysql_client.close()
+    return container_refs
+
+
+def _get_ao_refs_for_top_container_from_db(
+    db_settings: dict,
+    top_container_id: int,
+) -> list[str]:
+    """Return de-duped archival object refs linked to the given top container ID
+    via a database query. Filters for published and non-suppressed archival objects.
+
+    :param dict db_settings: A dict with DB connection details.
+    :param int top_container_id: ASpace top container ID.
+    :return: A list of archival object refs.
+    """
+    mysql_client = connect(
+        host=db_settings.get("host"),
+        database=db_settings.get("database"),
+        user=db_settings.get("user"),
+        password=db_settings.get("password"),
+    )
+
+    # This adapts the query used in `_get_container_refs_from_db` to return
+    # the set of archival object refs linked to the given top container.
+    query = """
+        select distinct 
+            concat('/repositories/', r.repo_id, '/archival_objects/', ao.id) as ao_uri
+        from resource r
+        inner join archival_object ao on r.id = ao.root_record_id
+        inner join instance i on ao.id = i.archival_object_id
+        inner join sub_container sc on i.id = sc.instance_id
+        inner join top_container_link_rlshp tclr on sc.id = tclr.sub_container_id
+        inner join top_container tc on tclr.top_container_id = tc.id
+        where tc.id = %s
+        and ao.publish = 1
+        and ao.suppressed = 0
+        order by ao_uri
+    """
+
+    cursor = mysql_client.cursor(DictCursor)
+    cursor.execute(query, (top_container_id,))
+    ao_refs = [row["ao_uri"] for row in cursor.fetchall()]
+    cursor.close()
+    mysql_client.close()
+    return ao_refs

--- a/python/cleanup_compound_indicators_aspace.py
+++ b/python/cleanup_compound_indicators_aspace.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from asnake.client import ASnakeClient
 
 from aspace_utils import (
-    _get_container_refs_from_api,
     _get_container_refs_from_db,
     _get_ao_refs_for_top_container_from_db,
 )
@@ -35,14 +34,17 @@ def _configure_logging() -> None:
 def _get_args() -> argparse.Namespace:
     """Get command-line arguments for this program."""
     parser = argparse.ArgumentParser(
-        description="Cleanup compound box indicators in ArchivesSpace."
+        description="Cleanup compound indicators in ArchivesSpace."
     )
     parser.add_argument(
         "-c",
         "--config_file",
         type=str,
         required=True,
-        help="Path to YAML config file with ArchivesSpace credentials.",
+        help=(
+            "Path to YAML config file with ArchivesSpace credentials, "
+            "including database connection settings."
+        ),
     )
     parser.add_argument(
         "--repo_id",
@@ -59,14 +61,9 @@ def _get_args() -> argparse.Namespace:
         help="ArchivesSpace resource ID to process.",
     )
     parser.add_argument(
-        "--use_db",
-        action="store_true",
-        help="Get containers from database instead of API.",
-    )
-    parser.add_argument(
         "--dry_run",
         action="store_true",
-        help="Dry run: log would-be actions without updating ArchivesSpace.",
+        help="Log intended actions without updating ArchivesSpace.",
     )
     return parser.parse_args()
 
@@ -130,16 +127,16 @@ def _parse_compound_indicator(indicator: str) -> list[str]:
 
 def _get_all_top_containers(
     aspace_client: ASnakeClient,
+    resource_uri: str,
     resource_id: int,
-    use_db: bool,
-    db_config: dict | None,
+    db_config: dict,
 ) -> tuple[list[dict], set[str], dict[str, list[dict]]]:
     """Fetch all top containers linked to the given resource.
 
     :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
-    :param int resource_id: ASpace resource ID for the target collection.
-    :param bool use_db: If True, fetch container refs via DB query; otherwise via API.
-    :param dict db_config: DB connection settings, required when use_db is True.
+    :param str resource_uri: The URI of the resource to process.
+    :param int resource_id: The ID of the resource to process.
+    :param dict db_config: DB connection settings.
     :return: A tuple of:
         - all_tcs: full dictionaries for every top container linked to the resource.
         - existing_indicators: set of all existing indicator strings for the resource.
@@ -147,15 +144,11 @@ def _get_all_top_containers(
         - tcs_by_indicator: dict with indicators as keys,
             and lists of TCs with that indicator as values, for duplicate checks.
     """
-    if use_db:
-        if not db_config:
-            raise ValueError("db_config is required when use_db is True")
-        container_refs = _get_container_refs_from_db(db_config, resource_id)
-    else:
-        container_refs = _get_container_refs_from_api(aspace_client, resource_id)
+    container_refs = _get_container_refs_from_db(db_config, resource_id)
 
     logger.info(
-        f"Fetched {len(container_refs)} container refs for resource {resource_id}"
+        f"Fetched {len(container_refs)} container ref{'s' if len(container_refs) > 1 else ''} "
+        f"from {resource_uri}"
     )
 
     all_tcs: list[dict] = []
@@ -202,54 +195,44 @@ def _post_top_container(
     :param dict tc_body: JSONModel body for the new top container.
     :param bool dry_run: If True, log the intended action without making the API call.
     """
-    if dry_run:
-        logger.info(
-            f"DRY RUN: Would create top container for "
-            f"{tc_body.get('type')} {tc_body.get('indicator')}"
-        )
-        return f"MOCK URI FOR {tc_body.get('type')} {tc_body.get('indicator')}"
-
-    response = aspace_client.post(
-        f"/repositories/{repo_id}/top_containers", json=tc_body
-    ).json()
-    if response.get("status") != "Created":
-        logger.error(f"Failed to create top container {tc_body}: {response}")
-        return None
-
-    new_uri = f"/repositories/{repo_id}/top_containers/{response['id']}"
-    logger.info(f"Created top container {new_uri}")
+    if not dry_run:
+        response = aspace_client.post(
+            f"/repositories/{repo_id}/top_containers", json=tc_body
+        ).json()
+        new_uri = f"/repositories/{repo_id}/top_containers/{response['id']}"
+    else:
+        new_uri = f"/repositories/{repo_id}/top_containers/{{NEW_TC_ID}}"
+    logger.info(
+        f"{'DRY RUN: Would create' if dry_run else 'Created'} new top container {new_uri}"
+    )
     return new_uri
 
 
-def _update_archival_object(
+def _post_archival_object(
     aspace_client: ASnakeClient,
     ao_ref: str,
-    original_tc_uri: str,
-    new_tc_uri: str,
+    ao_body: dict,
     dry_run: bool,
 ) -> None:
-    """Update an archival object to link to a new top container."""
-    archival_object = aspace_client.get(ao_ref).json()
-    instances = archival_object.get("instances", [])
-    for instance in instances:
-        sub_container = instance.get("sub_container", {})
-        top_container = sub_container.get("top_container", {})
-        if top_container.get("ref") == original_tc_uri:
-            top_container["ref"] = new_tc_uri
-            break
+    """POST an archival object to ArchivesSpace.
+
+    NOTE: The ASpace API uses POST to update archival objects,
+    not PUT or PATCH.
+
+    :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
+    :param str ao_ref: The URI of the archival object to update.
+    :param dict ao_body: The body of the archival object.
+    :param bool dry_run: If True, log the intended updates without POSTing.
+    """
     if not dry_run:
-        response = aspace_client.post(ao_ref, json=archival_object).json()
-        if response.get("status") != "Updated":
-            logger.error(f"Failed to update archival object {ao_ref}: {response}")
-            return
+        response = aspace_client.post(ao_ref, json=ao_body).json()
     logger.info(
         f"{'DRY RUN: Would update' if dry_run else 'Updated'} "
-        f"top container ref on archival object {ao_ref} "
-        f"from {original_tc_uri} to {new_tc_uri}"
+        f"instance(s) on archival object {ao_ref}"
     )
 
 
-def _relink_and_cleanup_archival_objects(
+def _relink_archival_objects(
     aspace_client: ASnakeClient,
     original_tc: dict,
     new_tc_uris: list[str],
@@ -257,51 +240,86 @@ def _relink_and_cleanup_archival_objects(
     dry_run: bool,
 ) -> None:
     """Handles relinking archival objects from `original_tc`
-    to individual top containers (`new_tc_uris`).
+    to individual top containers `new_tc_uris`.
 
     :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
     :param dict original_tc: The compound top container record being replaced.
     :param list[str] new_tc_uris: URIs of individual top containers to link.
+    :param dict db_config: DB connection settings.
     :param bool dry_run: If True, log the intended updates without POSTing.
     """
-    # Get archival object instances linked to the compound top container.
+    # Parse ID from original TC URI,
+    # because it's much faster when querying the DB.
     original_tc_uri = original_tc.get("uri", "")
     original_tc_id = int(original_tc_uri.split("/")[-1])
 
+    # There is no good way to retrieve all AOs linked to a TC via the API,
+    # so we use a database query instead.
     ao_refs = _get_ao_refs_for_top_container_from_db(db_config, original_tc_id)
     logger.info(
-        f"Found {len(ao_refs)} archival objects linked to "
-        f"compound top container {original_tc_uri}"
+        f"Found {len(ao_refs)} archival object{'s' if len(ao_refs) > 1 else ''} "
+        f"linked to compound top container {original_tc_uri}"
     )
 
+    # For each AO linked to the original TC,
+    # relink it to each of the new, individual TCs.
     for ao_ref in ao_refs:
+        archival_object = aspace_client.get(ao_ref).json()
+
+        # Find the instance within the AO with ref to the original TC.
+        # The path of the ref is instance > sub_container > top_container > ref.
+        original_instances = archival_object.get("instances", [])
+        new_instances = []
+        instance_type = ""
+        for instance in original_instances:
+            sub_container = instance.get("sub_container", {})
+            top_container = sub_container.get("top_container", {})
+            if top_container.get("ref") == original_tc_uri:
+                # Preserve instance type from original instance.
+                instance_type = instance.get("instance_type", "")
+
+        # Add new instances to the AO with ref to each of the new, individual TCs,
+        # with instance type preserved from original instance.
         for new_tc_uri in new_tc_uris:
-            _update_archival_object(
-                aspace_client, ao_ref, original_tc_uri, new_tc_uri, dry_run
+            new_instances.append(
+                {
+                    "instance_type": instance_type,
+                    "sub_container": {"top_container": {"ref": new_tc_uri}},
+                }
             )
+            logger.info(
+                f"Relinked archival object {ao_ref} to top container {new_tc_uri}"
+            )
+
+        # If the instances have changed, POST the updated AO to ArchivesSpace,
+        # or log the intended update if dry_run.
+        if original_instances != new_instances:
+            archival_object["instances"] = new_instances
+            _post_archival_object(aspace_client, ao_ref, archival_object, dry_run)
 
 
 def _delete_top_container(
     aspace_client: ASnakeClient, tc_uri: str, dry_run: bool
 ) -> None:
-    """Delete the given top container URI."""
-    if dry_run:
-        logger.info(f"DRY RUN: Would delete compound top container {tc_uri}")
-        return
+    """Delete the given top container URI.
 
-    response = aspace_client.delete(tc_uri).json()
-    if response.get("status") != "Deleted":
-        logger.error(f"Failed to delete top container {tc_uri}: {response}")
-        return
-    logger.info(f"Deleted compound top container {tc_uri}")
+    :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
+    :param str tc_uri: The URI of the top container to delete.
+    :param bool dry_run: If True, log the intended deletion without making the API call.
+    """
+    if not dry_run:
+        aspace_client.delete(tc_uri).json()
+    logger.info(
+        f"{'DRY RUN: Would delete' if dry_run else 'Deleted'} "
+        f"compound top container {tc_uri}"
+    )
 
 
 def _process_resource(
     aspace_client: ASnakeClient,
     repo_id: int,
     resource_id: int,
-    use_db: bool,
-    db_config: dict | None,
+    db_config: dict,
     dry_run: bool,
 ) -> None:
     """Cleanup compound box indicators for the given resource.
@@ -309,17 +327,17 @@ def _process_resource(
     :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
     :param int repo_id: Target ASpace repository ID.
     :param int resource_id: ASpace resource ID for the target collection.
-    :param bool use_db: If True, fetch container refs via DB query, otherwise via API,
-        which may timeout if the resource has many top containers.
-    :param dict db_config: DB connection settings, required when use_db is True.
+    :param dict db_config: DB connection settings.
     :param bool dry_run: If True, log all intended changes without making API writes.
     """
     if dry_run:
         logger.info(f"DRY RUN--NO UPDATES WILL BE MADE")
-    logger.info(f"Processing resource {resource_id}")
+
+    resource_uri = f"/repositories/{repo_id}/resources/{resource_id}"
+    logger.info(f"Processing resource at {resource_uri}")
 
     all_tcs, existing_indicators, tcs_by_indicator = _get_all_top_containers(
-        aspace_client, resource_id, use_db, db_config
+        aspace_client, resource_uri, resource_id, db_config
     )
 
     compound_tcs = [
@@ -331,8 +349,8 @@ def _process_resource(
         )  # check for comma or hyphen in indicator
     ]
     logger.info(
-        f"Found {len(compound_tcs)} top containers "
-        f"with compound indicators in resource {resource_id}"
+        f"Found {len(compound_tcs)} top container{'s' if len(compound_tcs) > 1 else ''} "
+        f"with compound indicators at {resource_uri}"
     )
 
     for compound_tc in compound_tcs:
@@ -397,7 +415,7 @@ def _process_resource(
                     continue
         # Use list of reused or new top containers to relink archival objects
         # then delete the original compound top container.
-        _relink_and_cleanup_archival_objects(
+        _relink_archival_objects(
             aspace_client, compound_tc, individual_uris, db_config, dry_run
         )
         _delete_top_container(aspace_client, compound_uri, dry_run)
@@ -422,13 +440,14 @@ def main() -> None:
     args = _get_args()
 
     aspace_client = ASnakeClient(config_file=args.config_file)
-    db_config = aspace_client.config.get("database") if args.use_db else None
+    db_config = aspace_client.config.get("database")
+    if not db_config:
+        raise ValueError("DB connection settings are required.")
 
     _process_resource(
         aspace_client=aspace_client,
         repo_id=args.repo_id,
         resource_id=args.resource_id,
-        use_db=args.use_db,
         db_config=db_config,
         dry_run=args.dry_run,
     )

--- a/python/cleanup_compound_indicators_aspace.py
+++ b/python/cleanup_compound_indicators_aspace.py
@@ -97,17 +97,21 @@ def _parse_compound_indicator(indicator: str) -> list[str]:
 
     :param str indicator: The compound indicator to parse.
     :return: A flat list of individual indicator values.
+    :raises ValueError: If the indicator cannot be parsed safely.
     """
+    # Normalize "&" and " and " (case-insensitive) to commas.
+    cleaned_indicator = re.sub(r"&|\band\b", ",", indicator, flags=re.IGNORECASE)
     # Split on commas first to handle mixed cases, then expand any ranges in each part.
     parts = [
-        part.strip() for part in indicator.split(",") if part.strip()
+        part.strip() for part in cleaned_indicator.split(",") if part.strip()
     ]  # `if part.strip()` filters out any empty segments
 
     expanded: list[str] = []
     for part in parts:
-        if re.match(r"^\[?\d+-\d+\]?$", part):  # match 1-3 or [1-3]
-            # Remove any brackets from range.
-            part = part.strip("[]")
+        # Remove any square brackets
+        part = part.strip("[]")
+        # Match numeric ranges, e.g. 1-3
+        if re.match(r"^\d+-\d+$", part):
             try:
                 expanded_range = _expand_range(part)
                 expanded.extend(expanded_range)
@@ -357,13 +361,15 @@ def _process_resource(
         aspace_client, resource_uri, resource_id, db_config
     )
 
+    # Regex checks for commas, numeric ranges, "&", or " and " (case-insensitive)
+    compound_indicator_pattern = r",|\d+-\d+|&|\band\b"
     compound_tcs = [
         tc
         for tc in all_tcs
         if tc.get("type", "") == "box"
-        and any(
-            delimiter in tc.get("indicator", "") for delimiter in [",", "-"]
-        )  # check for comma or hyphen in indicator
+        and re.search(
+            compound_indicator_pattern, tc.get("indicator", ""), flags=re.IGNORECASE
+        )
     ]
     logger.info(
         f"Found {len(compound_tcs)} top container{'s' if len(compound_tcs) > 1 else ''} "

--- a/python/cleanup_compound_indicators_aspace.py
+++ b/python/cleanup_compound_indicators_aspace.py
@@ -4,31 +4,20 @@ import copy
 import re
 
 from collections import defaultdict
-from datetime import datetime
 from pathlib import Path
 from asnake.client import ASnakeClient
 
-from aspace_utils import (
-    _get_container_refs_from_db,
-    _get_ao_refs_for_top_container_from_db,
+from utils import configure_logging
+from utils.aspace_utils import (
+    get_ao_refs_for_top_container_from_db,
+    get_container_refs_from_db,
 )
 
 
 # Logger available globally within this module.
-# Configuration is done by _configure_logging(), which is called by main().
+# Configuration is done by configure_logging(), which is called by main().
 # Made available globally so that tests can use the same logger with their own configuration.
 logger = logging.get_logger(Path(__file__).stem)
-
-
-def _configure_logging() -> None:
-    """Configure logging for the application."""
-    name = Path(__file__).stem
-    logs_dir = Path("logs")  # save logs to "./logs/"
-    logs_dir.mkdir(parents=True, exist_ok=True)  # create dir if it doesn't exist
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    logging_filename_base = f"{name}_{timestamp}"
-    logging_filename = logs_dir / f"{logging_filename_base}.log"
-    logging.setup_logging(filename=logging_filename, level="INFO")
 
 
 def _get_args() -> argparse.Namespace:
@@ -108,7 +97,8 @@ def _parse_compound_indicator(indicator: str) -> list[str]:
 
     expanded: list[str] = []
     for part in parts:
-        # Remove any square brackets
+        # Remove leading and trailing square brackets.
+        # Any other square brackets will need to be reviewed manually.
         part = part.strip("[]")
         # Match numeric ranges, e.g. 1-3
         if re.match(r"^\d+-\d+$", part):
@@ -148,7 +138,7 @@ def _get_all_top_containers(
         - tcs_by_indicator: dict with indicators as keys,
             and lists of TCs with that indicator as values, for duplicate checks.
     """
-    container_refs = _get_container_refs_from_db(db_config, resource_id)
+    container_refs = get_container_refs_from_db(db_config, resource_id)
 
     logger.info(
         f"Fetched {len(container_refs)} container ref{'s' if len(container_refs) > 1 else ''} "
@@ -188,12 +178,12 @@ def _build_new_top_container(compound_tc: dict, new_indicator: str) -> dict:
     return new_tc
 
 
-def _post_top_container(
+def _create_top_container(
     aspace_client: ASnakeClient, repo_id: int, tc_body: dict, dry_run: bool
 ) -> str | None:
-    """POST a new top container to ArchivesSpace.
+    """Create a new top container in ArchivesSpace.
 
-    Returns the new TC URI on success, or None if dry_run is True or the POST fails.
+    Returns the new TC URI on success, or None if dry_run is True or the API call fails.
 
     :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
     :param int repo_id: ASpace repository ID.
@@ -207,7 +197,7 @@ def _post_top_container(
             ).json()
             new_uri = f"/repositories/{repo_id}/top_containers/{response['id']}"
         except Exception as err:
-            logger.error(f"Error posting top container: {err}. Skipping.")
+            logger.error(f"Error creating top container: {err}. Skipping.")
             return None
     else:
         new_uri = f"/repositories/{repo_id}/top_containers/{{NEW_TC_ID}}"
@@ -217,27 +207,27 @@ def _post_top_container(
     return new_uri
 
 
-def _post_archival_object(
+def _update_archival_object(
     aspace_client: ASnakeClient,
     ao_ref: str,
     ao_body: dict,
     dry_run: bool,
 ) -> None:
-    """POST an archival object to ArchivesSpace.
+    """Update an archival object in ArchivesSpace.
 
     NOTE: The ASpace API uses POST to update archival objects,
-    not PUT or PATCH.
+    not PUT or PATCH as other APIs might.
 
     :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
     :param str ao_ref: The URI of the archival object to update.
     :param dict ao_body: The body of the archival object.
-    :param bool dry_run: If True, log the intended updates without POSTing.
+    :param bool dry_run: If True, log the intended updates without updating.
     """
     if not dry_run:
         try:
             aspace_client.post(ao_ref, json=ao_body).json()
         except Exception as err:
-            logger.error(f"Error posting archival object: {err}. Skipping.")
+            logger.error(f"Error updating archival object: {err}. Skipping.")
             return None
     logger.info(
         f"{'DRY RUN: Would update' if dry_run else 'Updated'} "
@@ -263,12 +253,16 @@ def _relink_archival_objects(
     """
     # Parse ID from original TC URI,
     # because it's much faster when querying the DB.
-    original_tc_uri = original_tc.get("uri", "")
+    # "0" used as default to satisfy int conversion in subsequent line,
+    # while also yielding an empty set from db query.
+    original_tc_uri = original_tc.get("uri", "0")
     original_tc_id = int(original_tc_uri.split("/")[-1])
 
     # There is no good way to retrieve all AOs linked to a TC via the API,
     # so we use a database query instead.
-    ao_refs = _get_ao_refs_for_top_container_from_db(db_config, original_tc_id)
+    ao_refs = get_ao_refs_for_top_container_from_db(db_config, original_tc_id)
+    if not ao_refs:
+        return  # no AOs linked to the original TC, so nothing to do.
     logger.info(
         f"Found {len(ao_refs)} archival object{'s' if len(ao_refs) > 1 else ''} "
         f"linked to compound top container {original_tc_uri}"
@@ -291,7 +285,7 @@ def _relink_archival_objects(
         for instance in original_instances:
             sub_container = instance.get("sub_container", {})
             top_container = sub_container.get("top_container", {})
-            if top_container.get("ref") == original_tc_uri:
+            if top_container.get("ref", "") == original_tc_uri:
                 # Preserve instance type from original instance.
                 instance_type = instance.get("instance_type", "")
 
@@ -308,17 +302,17 @@ def _relink_archival_objects(
                 f"Relinked archival object {ao_ref} to top container {new_tc_uri}"
             )
 
-        # If the instances have changed, POST the updated AO to ArchivesSpace,
+        # If the instances have changed, update the AO in ArchivesSpace,
         # or log the intended update if dry_run.
         if original_instances != new_instances:
             archival_object["instances"] = new_instances
-            _post_archival_object(aspace_client, ao_ref, archival_object, dry_run)
+            _update_archival_object(aspace_client, ao_ref, archival_object, dry_run)
 
 
 def _delete_top_container(
     aspace_client: ASnakeClient, tc_uri: str, dry_run: bool
 ) -> None:
-    """Delete the given top container URI.
+    """Delete the given top container.
 
     :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
     :param str tc_uri: The URI of the top container to delete.
@@ -336,7 +330,7 @@ def _delete_top_container(
     )
 
 
-def _process_resource(
+def _cleanup_compound_indicators(
     aspace_client: ASnakeClient,
     repo_id: int,
     resource_id: int,
@@ -366,7 +360,7 @@ def _process_resource(
     compound_tcs = [
         tc
         for tc in all_tcs
-        if tc.get("type", "") == "box"
+        if tc.get("type", "") == "box"  # only concerned with boxes for now
         and re.search(
             compound_indicator_pattern, tc.get("indicator", ""), flags=re.IGNORECASE
         )
@@ -407,7 +401,7 @@ def _process_resource(
                 if len(existing_tcs) > 1:
                     logger.warning(
                         f"Found more than one top container with indicator '{indicator}' "
-                        f"in resource {resource_id}: {[tc.get('uri') for tc in existing_tcs]}. "
+                        f"in resource {resource_id}: {[tc.get('uri', '') for tc in existing_tcs]}. "
                         "Manual review required."
                     )
                     continue
@@ -424,7 +418,9 @@ def _process_resource(
             # then post it to ArchivesSpace.
             else:
                 new_body = _build_new_top_container(compound_tc, indicator)
-                new_uri = _post_top_container(aspace_client, repo_id, new_body, dry_run)
+                new_uri = _create_top_container(
+                    aspace_client, repo_id, new_body, dry_run
+                )
                 if new_uri:
                     individual_uris.append(new_uri)
                     existing_indicators.add(indicator)
@@ -445,11 +441,12 @@ def _process_resource(
 
 
 def main() -> None:
-    """Cleanup top containers in ArchivesSpace that have a compound box indicator,
-    meaning the indicator is given as either a comma-separated list or a range.
+    """Within a given ArchivesSpace resource (i.e. collection),
+    cleanup top containers that have a compound box indicator,
+    meaning the indicator contains either a comma-separated list or a hyphenated numeric range.
 
     Summary of steps provided by LSC:
-        1. Get all top containers for a given collection.
+        1. Get all top containers for a given resource (i.e. collection).
         2. Find containers with compound indicators.
         3. Split each compound indicator into individual values.
         4. For each value, reuse a matching existing container if found,
@@ -459,7 +456,7 @@ def main() -> None:
         6. Remove archival object links to the original compound container.
         7. Delete the original compound container.
     """
-    _configure_logging()
+    configure_logging(Path(__file__).stem)
     args = _get_args()
 
     aspace_client = ASnakeClient(config_file=args.config_file)
@@ -467,7 +464,7 @@ def main() -> None:
     if not db_config:
         raise ValueError("DB connection settings are required.")
 
-    _process_resource(
+    _cleanup_compound_indicators(
         aspace_client=aspace_client,
         repo_id=args.repo_id,
         resource_id=args.resource_id,

--- a/python/cleanup_compound_indicators_aspace.py
+++ b/python/cleanup_compound_indicators_aspace.py
@@ -1,0 +1,398 @@
+import argparse
+import asnake.logging as logging
+import copy
+import re
+
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from asnake.client import ASnakeClient
+
+from add_alma_barcodes_to_archivesspace import (
+    _get_container_refs_from_api,
+    _get_container_refs_from_db,
+)
+
+
+# Logger available globally within this module.
+# Configuration is done by _configure_logging(), which is called by main().
+# Made available globally so that tests can use the same logger with their own configuration.
+logger = logging.get_logger(Path(__file__).stem)
+
+
+def _configure_logging() -> None:
+    """Configure logging for the application."""
+    name = Path(__file__).stem
+    logs_dir = Path("logs")  # save logs to "./logs/"
+    logs_dir.mkdir(parents=True, exist_ok=True)  # create dir if it doesn't exist
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    logging_filename_base = f"{name}_{timestamp}"
+    logging_filename = logs_dir / f"{logging_filename_base}.log"
+    logging.setup_logging(filename=logging_filename, level="INFO")
+
+
+def _get_args() -> argparse.Namespace:
+    """Get command-line arguments for this program."""
+    parser = argparse.ArgumentParser(
+        description="Cleanup compound box indicators in ArchivesSpace."
+    )
+    parser.add_argument(
+        "-c",
+        "--config_file",
+        type=str,
+        required=True,
+        help="Path to YAML config file with ArchivesSpace credentials.",
+    )
+    parser.add_argument(
+        "--repo_id",
+        type=int,
+        required=False,
+        default=2,
+        help="ArchivesSpace repository ID to target. Defaults to 2.",
+    )
+    parser.add_argument(
+        "-r",
+        "--resource_id",
+        type=int,
+        required=True,
+        help="ArchivesSpace resource ID to process.",
+    )
+    parser.add_argument(
+        "--use_db",
+        action="store_true",
+        help="Get containers from database instead of API.",
+    )
+    parser.add_argument(
+        "--dry_run",
+        action="store_true",
+        help="Dry run: log would-be actions without updating ArchivesSpace.",
+    )
+    return parser.parse_args()
+
+
+def _expand_range(indicator: str) -> list[str]:
+    """Expand a numeric range into individual values, if possible.
+        E.g. "38-42" -> ["38", "39", "40", "41", "42"].
+
+    :param str indicator: A single indicator segment to expand.
+    :return: A list of individual indicator values.
+    :raises ValueError: If the range cannot be expanded and requires manual review.
+    """
+    left, right = indicator.split("-")
+    if left.isdigit() and right.isdigit():
+        start, end = int(left), int(right)
+        if start > end:
+            # Start of range cannot be greater than end of range.
+            raise ValueError(f"Start {start} > end {end}")
+        return [f"{n}" for n in range(int(left), int(right) + 1)]
+    # Anything else is not a valid numeric range.
+    raise ValueError(f"Not a valid numeric range")
+
+
+def _parse_compound_indicator(indicator: str) -> list[str]:
+    """Parse a compound indicator into its individual values.
+
+    For example:
+    - Comma-separated lists: "29, 32a, 37" -> ["29", "32a", "37"]
+    - Numeric ranges: "38-42" -> ["38", "39", "40", "41", "42"]
+    - Mixed: "1-3, 5a" -> ["1", "2", "3", "5a"]
+
+    :param str indicator: The compound indicator to parse.
+    :return: A flat list of individual indicator values.
+    """
+    # Split on commas first to handle mixed cases, then expand any ranges in each part.
+    parts = [
+        part.strip() for part in indicator.split(",") if part.strip()
+    ]  # `if part.strip()` filters out any empty segments
+
+    expanded: list[str] = []
+    for part in parts:
+        if re.match(r"^\[?\d+-\d+\]?$", part):  # match 1-3 or [1-3]
+            # Remove any brackets from range.
+            part = part.strip("[]")
+            try:
+                expanded_range = _expand_range(part)
+                expanded.extend(expanded_range)
+            except ValueError as err:
+                # Re-raise a ValueError if a range part cannot be expanded,
+                # so caller can log a warning and skip this indicator.
+                raise ValueError(f"Cannot expand range '{part}': {err}")
+        # Individual indicators must be alphanumeric, like 1, 2, or 3a
+        elif part.isalnum():
+            expanded.append(part)
+        # Everything else cannot be parsed safely and requires manual review.
+        else:
+            raise ValueError(f"Unexpected indicator format: '{indicator}'")
+    # Return a deduplicated list of individual indicators, preserving order.
+    return list(dict.fromkeys(expanded))
+
+
+def _get_all_top_containers(
+    aspace_client: ASnakeClient,
+    resource_id: int,
+    use_db: bool,
+    db_config: dict | None,
+) -> tuple[list[dict], set[str], dict[str, list[dict]]]:
+    """Fetch all top containers linked to the given resource.
+
+    :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
+    :param int resource_id: ASpace resource ID for the target collection.
+    :param bool use_db: If True, fetch container refs via DB query; otherwise via API.
+    :param dict db_config: DB connection settings, required when use_db is True.
+    :return: A tuple of:
+        - all_tcs: full dictionaries for every top container linked to the resource.
+        - existing_indicators: set of all existing indicator strings for the resource.
+            Used for quick checks if an indicator already exists.
+        - tcs_by_indicator: dict with indicators as keys,
+            and lists of TCs with that indicator as values, for duplicate checks.
+    """
+    if use_db:
+        if not db_config:
+            raise ValueError("db_config is required when use_db is True")
+        container_refs = _get_container_refs_from_db(db_config, resource_id)
+    else:
+        container_refs = _get_container_refs_from_api(aspace_client, resource_id)
+
+    logger.info(
+        f"Fetched {len(container_refs)} container refs for resource {resource_id}"
+    )
+
+    all_tcs: list[dict] = []
+    for ref in container_refs:
+        tc = aspace_client.get(ref).json()
+        if "error" in tc:
+            logger.error(f"Error fetching top container {ref}: {tc['error']}")
+            continue
+        all_tcs.append(tc)
+
+    existing_indicators: set[str] = {tc.get("indicator", "") for tc in all_tcs}
+
+    # Group top containers by indicator to surface duplicates and make lookups quicker.
+    tcs_by_indicator: defaultdict[str, list[dict]] = defaultdict(list)
+    for tc in all_tcs:
+        indicator = tc.get("indicator", "")
+        tcs_by_indicator[indicator].append(tc)
+
+    return all_tcs, existing_indicators, tcs_by_indicator
+
+
+def _build_new_top_container(compound_tc: dict, new_indicator: str) -> dict:
+    """Build a new top container using `new_indicator`,
+    while copying all other fields from `compound_tc`.
+
+    :param dict compound_tc: The source top container record with a compound indicator.
+    :param str new_indicator: The indicator value for the new top container.
+    :return: The new top container record.
+    """
+    new_tc = copy.deepcopy(compound_tc)
+    new_tc["indicator"] = new_indicator
+    return new_tc
+
+
+def _post_top_container(
+    aspace_client: ASnakeClient, repo_id: int, tc_body: dict, dry_run: bool
+) -> str | None:
+    """POST a new top container to ArchivesSpace.
+
+    Returns the new TC URI on success, or None if dry_run is True or the POST fails.
+
+    :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
+    :param int repo_id: ASpace repository ID.
+    :param dict tc_body: JSONModel body for the new top container.
+    :param bool dry_run: If True, log the intended action without making the API call.
+    """
+    if dry_run:
+        logger.info(
+            f"DRY RUN: Would create top container for "
+            f"{tc_body.get('type')} {tc_body.get('indicator')}"
+        )
+        return f"MOCK URI FOR {tc_body.get('type')} {tc_body.get('indicator')}"
+
+    response = aspace_client.post(
+        f"/repositories/{repo_id}/top_containers", json=tc_body
+    ).json()
+    if response.get("status") != "Created":
+        logger.error(f"Failed to create top container {tc_body}: {response}")
+        return None
+
+    new_uri = f"/repositories/{repo_id}/top_containers/{response['id']}"
+    logger.info(f"Created top container {new_uri}")
+    return new_uri
+
+
+def _relink_and_cleanup_archival_objects(
+    aspace_client: ASnakeClient,
+    compound_tc: dict,
+    new_tc_uris: list[str],
+    dry_run: bool,
+) -> None:
+    """Handles relinking archival objects from `compound_tc`
+    to individual top containers (`new_tc_uris`).
+
+    :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
+    :param dict compound_tc: The compound top container record being replaced.
+    :param list[str] new_tc_uris: URIs of individual top containers to link.
+    :param bool dry_run: If True, log the intended updates without POSTing.
+    """
+    # Get archival object instances linked to the compound top container.
+    compound_uri = compound_tc.get("uri")
+    # TODO: Figure out how to relink archival objects from the original compound container
+    # to the new individual containers.
+    pass
+
+
+def _delete_top_container(
+    aspace_client: ASnakeClient, tc_uri: str, dry_run: bool
+) -> None:
+    """Delete the given top container URI."""
+    if dry_run:
+        logger.info(f"DRY RUN: Would delete compound top container {tc_uri}")
+        return
+
+    response = aspace_client.delete(tc_uri).json()
+    if response.get("status") != "Deleted":
+        logger.error(f"Failed to delete top container {tc_uri}: {response}")
+        return
+    logger.info(f"Deleted compound top container {tc_uri}")
+
+
+def _process_resource(
+    aspace_client: ASnakeClient,
+    repo_id: int,
+    resource_id: int,
+    use_db: bool,
+    db_config: dict | None,
+    dry_run: bool,
+) -> None:
+    """Cleanup compound box indicators for the given resource.
+
+    :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
+    :param int repo_id: Target ASpace repository ID.
+    :param int resource_id: ASpace resource ID for the target collection.
+    :param bool use_db: If True, fetch container refs via DB query, otherwise via API,
+        which may timeout if the resource has many top containers.
+    :param dict db_config: DB connection settings, required when use_db is True.
+    :param bool dry_run: If True, log all intended changes without making API writes.
+    """
+    if dry_run:
+        logger.info(f"DRY RUN--NO UPDATES WILL BE MADE")
+    logger.info(f"Processing resource {resource_id}")
+
+    all_tcs, existing_indicators, tcs_by_indicator = _get_all_top_containers(
+        aspace_client, resource_id, use_db, db_config
+    )
+
+    compound_tcs = [
+        tc
+        for tc in all_tcs
+        if tc.get("type", "") == "box"
+        and any(
+            delimiter in tc.get("indicator", "") for delimiter in [",", "-"]
+        )  # check for comma or hyphen in indicator
+    ]
+    logger.info(
+        f"Found {len(compound_tcs)} top containers "
+        f"with compound indicators in resource {resource_id}"
+    )
+
+    for compound_tc in compound_tcs:
+        compound_uri = compound_tc.get("uri", "")
+        compound_indicator = compound_tc.get("indicator", "")
+
+        try:
+            individual_indicators = _parse_compound_indicator(compound_indicator)
+        except ValueError as err:
+            # Skip indicators that cannot be safely parsed.
+            logger.warning(
+                f"Cannot safely parse compound indicator on {compound_uri}: {err}. "
+                f"Manual review required."
+            )
+            continue
+
+        logger.info(
+            f"Parsed compound indicator for {compound_uri}: "
+            f"'{compound_indicator}' -> {individual_indicators}"
+        )
+
+        # List to hold URIs for the individual top containers
+        # that will be used for archival object relinking later.
+        individual_uris: list[str] = []
+        for indicator in individual_indicators:
+            # Check if the indicator already exists in the collection,
+            # and if so, add it to the list of individual URIs.
+            if indicator in existing_indicators:
+                existing_tcs = tcs_by_indicator[indicator]
+                # Log any cases where there is more than 1 TC with the same indicator
+                if len(existing_tcs) > 1:
+                    logger.warning(
+                        f"Found more than one top container with indicator '{indicator}' "
+                        f"in resource {resource_id}: {[tc.get('uri') for tc in existing_tcs]}. "
+                        "Manual review required."
+                    )
+                    continue
+                # After duplicate check, there should only be one TC per indicator,
+                # so we can safely use the first one.
+                existing_uri = existing_tcs[0].get("uri", "")
+                individual_uris.append(existing_uri)
+                logger.info(
+                    f"Top container with indicator '{indicator}' already exists at "
+                    f"{existing_uri}. It will be reused."
+                )
+            # Otherwise, build a new top container for the indicator,
+            # with the same type and container profile as the compound TC,
+            # then post it to ArchivesSpace.
+            else:
+                new_body = _build_new_top_container(compound_tc, indicator)
+                new_uri = _post_top_container(aspace_client, repo_id, new_body, dry_run)
+                if new_uri:
+                    individual_uris.append(new_uri)
+                    existing_indicators.add(indicator)
+                    tcs_by_indicator[indicator].append(
+                        {"uri": new_uri, "indicator": indicator}
+                    )
+                else:
+                    logger.error(
+                        f"Failed to create top container for indicator '{indicator}': {new_body}"
+                    )
+                    continue
+        # Use list of reused or new top containers to relink archival objects
+        # then delete the original compound top container.
+        _relink_and_cleanup_archival_objects(
+            aspace_client, compound_tc, individual_uris, dry_run
+        )
+        _delete_top_container(aspace_client, compound_uri, dry_run)
+
+
+def main() -> None:
+    """Cleanup top containers in ArchivesSpace that have a compound box indicator,
+    meaning the indicator is given as either a comma-separated list or a range.
+
+    Summary of steps provided by LSC:
+        1. Get all top containers for a given collection.
+        2. Find containers with compound indicators.
+        3. Split each compound indicator into individual values.
+        4. For each value, reuse a matching existing container if found,
+            or create a new one with copied metadata.
+        5. For each archival object linked to the compound container,
+            add new instances linked to each single-box container.
+        6. Remove archival object links to the original compound container.
+        7. Delete the original compound container.
+    """
+    _configure_logging()
+    args = _get_args()
+
+    aspace_client = ASnakeClient(config_file=args.config_file)
+    db_config = aspace_client.config.get("database") if args.use_db else None
+
+    _process_resource(
+        aspace_client=aspace_client,
+        repo_id=args.repo_id,
+        resource_id=args.resource_id,
+        use_db=args.use_db,
+        db_config=db_config,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/cleanup_compound_indicators_aspace.py
+++ b/python/cleanup_compound_indicators_aspace.py
@@ -84,7 +84,7 @@ def _expand_range(indicator: str) -> list[str]:
             raise ValueError(f"Start {start} > end {end}")
         return [f"{n}" for n in range(int(left), int(right) + 1)]
     # Anything else is not a valid numeric range.
-    raise ValueError(f"Not a valid numeric range")
+    raise ValueError("Not a valid numeric range")
 
 
 def _parse_compound_indicator(indicator: str) -> list[str]:
@@ -352,7 +352,7 @@ def _process_resource(
     :param bool dry_run: If True, log all intended changes without making API writes.
     """
     if dry_run:
-        logger.info(f"DRY RUN--NO UPDATES WILL BE MADE")
+        logger.info("DRY RUN--NO UPDATES WILL BE MADE")
 
     resource_uri = f"/repositories/{repo_id}/resources/{resource_id}"
     logger.info(f"Processing resource at {resource_uri}")

--- a/python/cleanup_compound_indicators_aspace.py
+++ b/python/cleanup_compound_indicators_aspace.py
@@ -8,9 +8,10 @@ from datetime import datetime
 from pathlib import Path
 from asnake.client import ASnakeClient
 
-from add_alma_barcodes_to_archivesspace import (
+from aspace_utils import (
     _get_container_refs_from_api,
     _get_container_refs_from_db,
+    _get_ao_refs_for_top_container_from_db,
 )
 
 
@@ -220,25 +221,64 @@ def _post_top_container(
     return new_uri
 
 
-def _relink_and_cleanup_archival_objects(
+def _update_archival_object(
     aspace_client: ASnakeClient,
-    compound_tc: dict,
-    new_tc_uris: list[str],
+    ao_ref: str,
+    original_tc_uri: str,
+    new_tc_uri: str,
     dry_run: bool,
 ) -> None:
-    """Handles relinking archival objects from `compound_tc`
+    """Update an archival object to link to a new top container."""
+    archival_object = aspace_client.get(ao_ref).json()
+    instances = archival_object.get("instances", [])
+    for instance in instances:
+        sub_container = instance.get("sub_container", {})
+        top_container = sub_container.get("top_container", {})
+        if top_container.get("ref") == original_tc_uri:
+            top_container["ref"] = new_tc_uri
+            break
+    if not dry_run:
+        response = aspace_client.post(ao_ref, json=archival_object).json()
+        if response.get("status") != "Updated":
+            logger.error(f"Failed to update archival object {ao_ref}: {response}")
+            return
+    logger.info(
+        f"{'DRY RUN: Would update' if dry_run else 'Updated'} "
+        f"top container ref on archival object {ao_ref} "
+        f"from {original_tc_uri} to {new_tc_uri}"
+    )
+
+
+def _relink_and_cleanup_archival_objects(
+    aspace_client: ASnakeClient,
+    original_tc: dict,
+    new_tc_uris: list[str],
+    db_config: dict,
+    dry_run: bool,
+) -> None:
+    """Handles relinking archival objects from `original_tc`
     to individual top containers (`new_tc_uris`).
 
     :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
-    :param dict compound_tc: The compound top container record being replaced.
+    :param dict original_tc: The compound top container record being replaced.
     :param list[str] new_tc_uris: URIs of individual top containers to link.
     :param bool dry_run: If True, log the intended updates without POSTing.
     """
     # Get archival object instances linked to the compound top container.
-    compound_uri = compound_tc.get("uri")
-    # TODO: Figure out how to relink archival objects from the original compound container
-    # to the new individual containers.
-    pass
+    original_tc_uri = original_tc.get("uri", "")
+    original_tc_id = int(original_tc_uri.split("/")[-1])
+
+    ao_refs = _get_ao_refs_for_top_container_from_db(db_config, original_tc_id)
+    logger.info(
+        f"Found {len(ao_refs)} archival objects linked to "
+        f"compound top container {original_tc_uri}"
+    )
+
+    for ao_ref in ao_refs:
+        for new_tc_uri in new_tc_uris:
+            _update_archival_object(
+                aspace_client, ao_ref, original_tc_uri, new_tc_uri, dry_run
+            )
 
 
 def _delete_top_container(
@@ -358,7 +398,7 @@ def _process_resource(
         # Use list of reused or new top containers to relink archival objects
         # then delete the original compound top container.
         _relink_and_cleanup_archival_objects(
-            aspace_client, compound_tc, individual_uris, dry_run
+            aspace_client, compound_tc, individual_uris, db_config, dry_run
         )
         _delete_top_container(aspace_client, compound_uri, dry_run)
 

--- a/python/cleanup_compound_indicators_aspace.py
+++ b/python/cleanup_compound_indicators_aspace.py
@@ -153,9 +153,10 @@ def _get_all_top_containers(
 
     all_tcs: list[dict] = []
     for ref in container_refs:
-        tc = aspace_client.get(ref).json()
-        if "error" in tc:
-            logger.error(f"Error fetching top container {ref}: {tc['error']}")
+        try:
+            tc = aspace_client.get(ref).json()
+        except Exception as err:
+            logger.error(f"Error fetching top container {ref}: {err}. Skipping.")
             continue
         all_tcs.append(tc)
 
@@ -196,10 +197,14 @@ def _post_top_container(
     :param bool dry_run: If True, log the intended action without making the API call.
     """
     if not dry_run:
-        response = aspace_client.post(
-            f"/repositories/{repo_id}/top_containers", json=tc_body
-        ).json()
-        new_uri = f"/repositories/{repo_id}/top_containers/{response['id']}"
+        try:
+            response = aspace_client.post(
+                f"/repositories/{repo_id}/top_containers", json=tc_body
+            ).json()
+            new_uri = f"/repositories/{repo_id}/top_containers/{response['id']}"
+        except Exception as err:
+            logger.error(f"Error posting top container: {err}. Skipping.")
+            return None
     else:
         new_uri = f"/repositories/{repo_id}/top_containers/{{NEW_TC_ID}}"
     logger.info(
@@ -225,7 +230,11 @@ def _post_archival_object(
     :param bool dry_run: If True, log the intended updates without POSTing.
     """
     if not dry_run:
-        response = aspace_client.post(ao_ref, json=ao_body).json()
+        try:
+            aspace_client.post(ao_ref, json=ao_body).json()
+        except Exception as err:
+            logger.error(f"Error posting archival object: {err}. Skipping.")
+            return None
     logger.info(
         f"{'DRY RUN: Would update' if dry_run else 'Updated'} "
         f"instance(s) on archival object {ao_ref}"
@@ -264,7 +273,11 @@ def _relink_archival_objects(
     # For each AO linked to the original TC,
     # relink it to each of the new, individual TCs.
     for ao_ref in ao_refs:
-        archival_object = aspace_client.get(ao_ref).json()
+        try:
+            archival_object = aspace_client.get(ao_ref).json()
+        except Exception as err:
+            logger.error(f"Error fetching archival object {ao_ref}: {err}. Skipping.")
+            continue
 
         # Find the instance within the AO with ref to the original TC.
         # The path of the ref is instance > sub_container > top_container > ref.
@@ -308,7 +321,11 @@ def _delete_top_container(
     :param bool dry_run: If True, log the intended deletion without making the API call.
     """
     if not dry_run:
-        aspace_client.delete(tc_uri).json()
+        try:
+            aspace_client.delete(tc_uri).json()
+        except Exception as err:
+            logger.error(f"Error deleting top container {tc_uri}: {err}. Skipping.")
+            return None
     logger.info(
         f"{'DRY RUN: Would delete' if dry_run else 'Deleted'} "
         f"compound top container {tc_uri}"

--- a/python/config/base_match.py
+++ b/python/config/base_match.py
@@ -5,7 +5,7 @@ def match_containers(
     alma_match_data: dict,
     aspace_match_data: dict,
     logger: Optional[Any] = None,
-) -> tuple[list[dict], dict[dict]]:
+) -> tuple[list[dict], dict[str, list[dict]]]:
     """
     Matches Alma items with ASpace top containers and adds barcodes to the matched top containers.
     Also returns lists of unmatched Alma items and ASpace top containers.
@@ -24,7 +24,7 @@ def match_containers(
     """
 
     # find matches by comparing keys in _match_data dictionaries
-    matched_aspace_containers = []
+    matched_aspace_containers: list[dict] = []
     for alma_key, alma_item in alma_match_data.items():
         if alma_key in aspace_match_data:
             tc = aspace_match_data[alma_key]
@@ -46,13 +46,15 @@ def match_containers(
     unmatched_alma_keys = alma_keys - aspace_keys
     unmatched_aspace_keys = aspace_keys - alma_keys
 
-    unmatched_alma_items = [alma_match_data[key] for key in unmatched_alma_keys]
-    unmatched_aspace_containers = [
+    unmatched_alma_items: list[dict] = [
+        alma_match_data[key] for key in unmatched_alma_keys
+    ]
+    unmatched_aspace_containers: list[dict] = [
         aspace_match_data[key] for key in unmatched_aspace_keys
     ]
 
     # assemble unhandled data dict
-    unhandled_data = {
+    unhandled_data: dict[str, list[dict]] = {
         "unmatched_alma_items": unmatched_alma_items,
         "unmatched_aspace_containers": unmatched_aspace_containers,
     }

--- a/python/config/indicator_only_matching.py
+++ b/python/config/indicator_only_matching.py
@@ -3,7 +3,7 @@ from typing import Optional, Any
 
 def get_aspace_match_data(
     aspace_containers: list, logger: Optional[Any] = None
-) -> tuple[dict[tuple, list[tuple]]]:
+) -> tuple[dict[tuple, dict], list[tuple]]:
     """Parses ASpace top container indicators into a dictionary."""
     match_data = {}
     tcs_with_duplicate_keys = []
@@ -31,13 +31,13 @@ def get_aspace_match_data(
 
 def get_alma_match_data(
     alma_items: list, logger: Optional[Any] = None
-) -> tuple[dict[tuple], list[tuple]]:
+) -> tuple[dict[tuple, dict], list[tuple]]:
     """Parses Alma item descriptions into indicators, and normalizes the indicator
     by removing leading zeroes and " RESTRICTED"."""
     match_data = {}
     items_with_duplicate_keys = []
     for item in alma_items:
-        description = item.get("description")
+        description = item.get("description", "")
         # split description into container type and indicator, e.g. "box.1"
         # keep only the indicator
         alma_indicator = description.split(".")[1]

--- a/python/config/indicator_type_matching.py
+++ b/python/config/indicator_type_matching.py
@@ -2,8 +2,8 @@ from typing import Optional, Any
 
 
 def get_aspace_match_data(
-    aspace_containers: list, logger: Optional[Any] = None
-) -> tuple[dict[tuple, list[tuple]]]:
+    aspace_containers: list[dict], logger: Optional[Any] = None
+) -> tuple[dict[tuple, dict], list[tuple]]:
     """Parses ASpace top container indicators and types into a dictionary."""
     match_data = {}
     tcs_with_duplicate_keys = []
@@ -31,14 +31,14 @@ def get_aspace_match_data(
 
 
 def get_alma_match_data(
-    alma_items: list, logger: Optional[Any] = None
-) -> tuple[dict[tuple], list[tuple]]:
+    alma_items: list[dict], logger: Optional[Any] = None
+) -> tuple[dict[tuple, dict], list[tuple]]:
     """Parses Alma item descriptions into container type and indicator,
     and normalizes the indicator by removing leading zeroes and " RESTRICTED"."""
     match_data = {}
     items_with_duplicate_keys = []
     for item in alma_items:
-        description = item.get("description")
+        description = item.get("description", "")
         # split description into container type and indicator, e.g. "box.1"
         alma_container_type = description.split(".")[0]
         alma_indicator = description.split(".")[1]

--- a/python/config/series_description_matching.py
+++ b/python/config/series_description_matching.py
@@ -11,21 +11,21 @@ def parse_aspace_indicator(tc_indicator_with_series: str) -> tuple[str, str]:
         parsed_indicators = re.findall(r"(\d+)(\w+)", tc_indicator_with_series)
         # if we have no matches or more than one match, indicator is not in the expected format
         if len(parsed_indicators) != 1:
-            return None, None
+            return "", ""
         (tc_indicator, tc_series) = parsed_indicators[0]
 
     # otherwise, format should be XYZ-123
     else:
         parsed_indicators = re.findall(r"(\w+)-(\d+)", tc_indicator_with_series)
         if len(parsed_indicators) != 1:
-            return None, None
+            return "", ""
         (tc_series, tc_indicator) = parsed_indicators[0]
     return tc_indicator, tc_series
 
 
 def get_aspace_match_data(
     aspace_containers: list, logger: Optional[Any] = None
-) -> tuple[dict[tuple, list[tuple]]]:
+) -> tuple[dict[tuple, dict], list[tuple]]:
     """Parses ASpace top container indicators into indicator and series and extracts the type.
     Returns a dictionary with the indicator, type, and series as keys, and a list of top
     containers with duplicate keys."""
@@ -83,7 +83,7 @@ def get_aspace_match_data(
 
 def get_alma_match_data(
     alma_items: list, logger: Optional[Any] = None
-) -> tuple[dict[tuple], list[tuple]]:
+) -> tuple[dict[tuple, dict], list[tuple]]:
     """Parses Alma item descriptions into container type, indicator, and series
     and normalizes the indicator by removing leading zeroes and trailing " RESTRICTED".
     Returns a dictionary with the normalized indicator, type, and series as keys, and
@@ -92,7 +92,7 @@ def get_alma_match_data(
     match_data = {}
     items_with_duplicate_keys = []
     for item in alma_items:
-        description = item.get("description")
+        description = item.get("description", "")
         # split description into series and container type/indicator (space and period delimited)
         # e.g. "ser.P box.0011" -> "P", "box", "0011"
         alma_series = description.split(" ")[0].split(".")[1]

--- a/python/tests/test_cleanup_compound_indicators_aspace.py
+++ b/python/tests/test_cleanup_compound_indicators_aspace.py
@@ -14,11 +14,16 @@ class TestParseCompoundIndicator(unittest.TestCase):
             ("38-42", ["38", "39", "40", "41", "42"]),
             ("1, 3, 3, 5-7", ["1", "3", "5", "6", "7"]),
             ("[1-3]", ["1", "2", "3"]),
+            ("[542-543, 554-556 & 762]", ["542", "543", "554", "555", "556", "762"]),
+            ("1 & 2, 3-5, 7 and 8", ["1", "2", "3", "4", "5", "7", "8"]),
+            ("[1, 3-5], [7-9]", ["1", "3", "4", "5", "7", "8", "9"]),
         ]
 
-        self.invalid_test_cases = [
-            ("38a-42a", ["38a-42a"]),
-            ("Foo-Bar", ["Foo-Bar"]),
+        # Only need inputs because we expect a ValueError to be raised
+        self.invalid_test_inputs = [
+            "38a-42a",
+            "Foo-Bar",
+            "3-5 and Oversize Box 8",
         ]
 
     def test_valid_compound_indicators(self):
@@ -27,7 +32,7 @@ class TestParseCompoundIndicator(unittest.TestCase):
                 self.assertEqual(_parse_compound_indicator(input), expected)
 
     def test_invalid_compound_indicators(self):
-        for input, _ in self.invalid_test_cases:
+        for input in self.invalid_test_inputs:
             with self.subTest(input=input):
                 # Invalid indicators should raise a ValueError.
                 self.assertRaises(ValueError, _parse_compound_indicator, input)

--- a/python/tests/test_cleanup_compound_indicators_aspace.py
+++ b/python/tests/test_cleanup_compound_indicators_aspace.py
@@ -1,0 +1,33 @@
+import unittest
+
+from cleanup_compound_indicators_aspace import _parse_compound_indicator
+
+
+class TestParseCompoundIndicator(unittest.TestCase):
+    """Test the `_parse_compound_indicator` function."""
+
+    def setUp(self):
+        # Tuples of (input string, expected output list)
+        self.valid_test_cases = [
+            ("29, 32a, 37, 41, 48", ["29", "32a", "37", "41", "48"]),
+            ("1,2,3", ["1", "2", "3"]),
+            ("38-42", ["38", "39", "40", "41", "42"]),
+            ("1, 3, 3, 5-7", ["1", "3", "5", "6", "7"]),
+            ("[1-3]", ["1", "2", "3"]),
+        ]
+
+        self.invalid_test_cases = [
+            ("38a-42a", ["38a-42a"]),
+            ("Foo-Bar", ["Foo-Bar"]),
+        ]
+
+    def test_valid_compound_indicators(self):
+        for input, expected in self.valid_test_cases:
+            with self.subTest(input=input):
+                self.assertEqual(_parse_compound_indicator(input), expected)
+
+    def test_invalid_compound_indicators(self):
+        for input, _ in self.invalid_test_cases:
+            with self.subTest(input=input):
+                # Invalid indicators should raise a ValueError.
+                self.assertRaises(ValueError, _parse_compound_indicator, input)

--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -1,0 +1,9 @@
+"""
+Re-export generic utilities so they can be imported directly from the utils package.
+
+E.g. `from utils import configure_logging` vs `from utils.generic_utils import configure_logging`.
+"""
+
+from .generic_utils import configure_logging
+
+__all__ = ["configure_logging"]

--- a/python/utils/aspace_utils.py
+++ b/python/utils/aspace_utils.py
@@ -1,7 +1,7 @@
 """
 Utility functions and helpers for working with ArchivesSpace.
 
-This module provides utility functions for interacting with ArchivesSpace
+This module provides utilities for interacting with ArchivesSpace
 that can be reused across multiple scripts in the toolkit.
 """
 
@@ -10,8 +10,8 @@ from MySQLdb import connect
 from MySQLdb.cursors import DictCursor
 
 
-def _get_container_refs_from_api(
-    aspace_client: ASnakeClient, resource_id: int
+def get_container_refs_from_api(
+    aspace_client: ASnakeClient, repo_id: int, resource_id: int
 ) -> set[str]:
     """Returns a de-duped set of _ref_ top container URIs for the given resource_id,
     obtained via API call.
@@ -19,16 +19,17 @@ def _get_container_refs_from_api(
     more than a few thousand containers are associated with the resource.
 
     :param ASnakeClient aspace_client: ASnakeClient instance.
+    :param int repo_id: ASpace repository ID from which to retrieve containers.
     :param int resource_id: ASpace resource ID for target collection.
     :return: A set of container refs.
     """
-    url = f"/repositories/2/resources/{resource_id}/top_containers"
+    url = f"/repositories/{repo_id}/resources/{resource_id}/top_containers"
     container_refs = aspace_client.get(url).json()
     # Extract the ref URIs and de-dup.
     return set(tc["ref"] for tc in container_refs)
 
 
-def _get_container_refs_from_db(db_settings: dict, resource_id: int) -> set[str]:
+def get_container_refs_from_db(db_settings: dict, resource_id: int) -> set[str]:
     """Returns a de-duped set of _ref_ top container URIs for the given resource_id,
     obtained via database query.
     This is intended as an alternative for resources with more than a few thousand
@@ -68,7 +69,7 @@ def _get_container_refs_from_db(db_settings: dict, resource_id: int) -> set[str]
     return container_refs
 
 
-def _get_ao_refs_for_top_container_from_db(
+def get_ao_refs_for_top_container_from_db(
     db_settings: dict,
     top_container_id: int,
 ) -> list[str]:

--- a/python/utils/generic_utils.py
+++ b/python/utils/generic_utils.py
@@ -1,0 +1,18 @@
+"""Generic logging setup helpers for reuse across scripts."""
+
+import asnake.logging as logging
+from datetime import datetime
+from pathlib import Path
+
+
+def configure_logging(log_filename_stem: str = "log") -> None:
+    """Configure ASnake logging using the provided log filename stem.
+
+    :param str log_filename_stem: The filename stem to use for the configured log file.
+        Defaults to "log".
+    """
+    logs_dir = Path("logs")  # save logs to "./logs/"
+    logs_dir.mkdir(parents=True, exist_ok=True)  # create dir if it doesn't exist
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_filename = logs_dir / f"{log_filename_stem}_{timestamp}.log"
+    logging.setup_logging(filename=log_filename, level="INFO")


### PR DESCRIPTION
Implements [DLSR-11](https://uclalibrary.atlassian.net/browse/DLSR-11)

### Summary of code logic
1. Get all top containers for a given collection.
2. Find containers with compound indicators.
3. Split each compound indicator into individual values.
4. For each value, reuse a matching existing container if found, or create a new one with copied metadata.
5. For each archival object linked to the compound container, add new instances linked to each single-box container.
6. Remove archival object links to the original compound container.
7. Delete the original compound container.

### Acceptance criteria
After running the script:
- [X] No archival objects lose container links
- [X] Each box-level container has a single, unambiguous Indicator
- [X] Container profiles and Instance types are preserved on newly created top containers
- [X] Compound containers no longer exist after processing

### Description
This PR adds a new script to cleanup top containers with compound indicators, i.e. those with comma-separated values or numeric ranges indicated by hyphens. The script identifies such top containers in a given resource/collection, parses the compound indicator into a list of discrete values, then creates new top containers or finds existing top containers using the values in the resulting list. It has a `dry_run` mode to log would-be changes without modifying anything, and it writes logs to a new `./logs` directory.

The script uses database queries for retrieving top container and archival object URIs, both to avoid potential timeout issues via the API on large collections and because there's no good way to retrieve a list of all archival objects linked to a particular top container via the API. All update actions are done via POST calls to the API, however.

Other changes include moving shared helper functions to the new `python/aspace_utils.py` module, for reuse across different scripts. The first couple commits address linter issues related to types in the existing `add_alma_barcodes_to_archivesspace.py` script and related scripts under `python/config`. I'll refactor `add_alma_barcodes_to_archivesspace.py` to use the helper functions in `python/aspace_utils.py` in a separate PR.

### Testing
I added unit tests in `python/tests/test_cleanup_compound_indicators_aspace.py` to cover the compound indicator parsing logic. There are now 16 unit tests for the toolkit, and all still pass after these changes. To run tests within the Python container: `docker compose exec python python -m unittest discover tests`

Julia from LSC [identified a few collections](https://uclalibrary.atlassian.net/browse/DLSR-11?focusedCommentId=712018) with multiple compound indicators for testing purposes. Using resource ID `1947` as an example, the following command can be run from within the Python container to see a dry run of the script:

`python cleanup_compound_indicators_aspace.py -c .archivessnake_secret_DEV.yml --resource_id 1947 --dry_run`

I ran the script in live mode against my local ArchivesSpace instance on resource `1947`. I can share my log file for that run separately for comparison.

[DLSR-11]: https://uclalibrary.atlassian.net/browse/DLSR-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ