### PR TITLE
DLSR-305: Report container mismatches b/w ASpace and Alma

### DIFF
--- a/python/find_missing_containers_aspace.py
+++ b/python/find_missing_containers_aspace.py
@@ -1,0 +1,216 @@
+import argparse
+import csv
+
+from alma_api_client import AlmaAPIClient
+from asnake.client import ASnakeClient
+from pathlib import Path
+
+from utils import load_config
+from utils.alma_utils import get_alma_items_from_alma
+from utils.aspace_utils import get_container_refs_from_db
+
+from config.base_match import match_containers
+from config.indicator_type_matching import get_aspace_match_data, get_alma_match_data
+
+
+def _get_args() -> argparse.Namespace:
+    """Get command-line arguments for this program."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Using ArchivesSpace and Alma IDs for the same LSC collection, "
+            "list Alma items whose box identifier has no matching top container in ArchivesSpace."
+        )
+    )
+    parser.add_argument(
+        "-c",
+        "--config_file",
+        type=str,
+        required=True,
+        help=(
+            "Path to YAML config file with ArchivesSpace credentials, "
+            "including database connection settings and Alma API key."
+        ),
+    )
+    parser.add_argument(
+        "--repo_id",
+        type=int,
+        required=False,
+        default=2,
+        help="ArchivesSpace repository ID. Defaults to 2.",
+    )
+    parser.add_argument(
+        "-r",
+        "--resource_id",
+        type=int,
+        required=True,
+        help="ArchivesSpace resource ID (i.e. collection) to process.",
+    )
+    parser.add_argument(
+        "--bib_id",
+        type=str,
+        required=True,
+        help="Alma bib MMS ID for the same collection.",
+    )
+    parser.add_argument(
+        "--holdings_id",
+        type=str,
+        required=True,
+        help="Alma holdings MMS ID for the same collection.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output_path",
+        type=str,
+        required=True,
+        help="Path to write the CSV report.",
+    )
+    return parser.parse_args()
+
+
+def _get_all_top_containers_for_resource(
+    aspace_client: ASnakeClient,
+    db_config: dict,
+    resource_id: int,
+) -> list[dict]:
+    """Fetch all top containers linked to the given resource.
+
+    :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
+    :param dict db_config: DB connection settings.
+    :param int resource_id: The ID of the resource to process.
+    :return: A list of top container dictionaries.
+    """
+    container_refs = get_container_refs_from_db(db_config, resource_id)
+
+    all_tcs: list[dict] = []
+    for ref in container_refs:
+        try:
+            tc = aspace_client.get(ref).json()
+        except Exception as err:
+            print(f"Error fetching top container {ref}: {err}. Skipping.")
+            continue
+        all_tcs.append(tc)
+    return all_tcs
+
+
+def _write_report_csv(
+    output_path: Path,
+    rows: list[dict],
+) -> None:
+    """Write the CSV report to the given output path.
+
+    :param Path output_path: Path to write the CSV report.
+    :param list[dict] rows: A list of CSV row dictionaries.
+    """
+    fieldnames = [
+        "ASpace Resource ID",
+        "Alma Bib ID",
+        "Alma Item Barcode",
+        "Alma Box Identifier",
+        "ASpace Match Found",
+        "Notes",
+    ]
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _prepare_report_rows(
+    unmatched_alma_items: list[dict],
+    resource_id: int,
+    bib_id: str,
+) -> list[dict]:
+    """Prepare CSV row dicts for unmatched Alma items.
+
+    :param list[dict] unmatched_alma_items: A list of Alma item dicts.
+    :param int resource_id: The ID of the ASpace resource.
+    :param str bib_id: The Alma bib ID.
+    :return list[dict]: A list of CSV row dictionaries.
+    """
+    rows: list[dict] = []
+    for alma_item in unmatched_alma_items:
+        rows.append(
+            {
+                "ASpace Resource ID": resource_id,
+                "Alma Bib ID": bib_id,
+                "Alma Item Barcode": alma_item.get("barcode", ""),
+                "Alma Box Identifier": alma_item.get("description", ""),
+                "ASpace Match Found": "No",  # this is always "No" for unmatched items
+                "Notes": "No matching ASpace top container found — requires review",
+            }
+        )
+    return rows
+
+
+def main() -> None:
+    """For a given LSC collection, produce a CSV report of boxes cataloged in Alma
+    that have no matching ArchivesSpace top container. Collections are identified by
+    ASpace resource ID and Alma bib and holdings IDs.
+
+    Summary of LSC ticket:
+    1. Retrieve all top containers from ArchivesSpace for the given collection,
+        and all Item records from Alma for the same collection.
+    2. Normalize the box identifiers to use the same format in each set.
+    3. Compare the two normalized sets and generate a CSV report with the following info:
+        - Alma item identifier / barcode
+        - Alma box identifier as it appears in the item record
+        - Collection identifier (ASpace resource ID)
+        - A status note: "No matching ASpace top container found — requires review"
+    """
+    args = _get_args()
+    config = load_config(args.config_file)
+
+    aspace_client = ASnakeClient(**config)
+    db_config = config.get("database")
+    if not db_config:
+        raise ValueError("DB connection settings are required.")
+
+    print(
+        f"Running container comparison report for "
+        f"ASpace resource ID: {args.resource_id}, "
+        f"Alma Bib ID: {args.bib_id}, "
+        f"Alma Holdings ID: {args.holdings_id}"
+    )
+
+    # Get all top containers for the given collection from ASpace
+    aspace_top_containers = _get_all_top_containers_for_resource(
+        aspace_client, db_config, args.resource_id
+    )
+    print(
+        f"Fetched {len(aspace_top_containers)} "
+        f"top container{'s' if len(aspace_top_containers) > 1 else ''} from ASpace"
+    )
+    # Reuse the `indicator_type_matching` logic to create aspace match data dict
+    aspace_match_data, _ = get_aspace_match_data(aspace_top_containers)
+
+    # Now get all items for the given collection from Alma
+    alma_api_key = config["alma_config"]["alma_api_key"]
+    alma_client = AlmaAPIClient(alma_api_key)
+    alma_items = get_alma_items_from_alma(alma_client, args.bib_id, args.holdings_id)
+    print(
+        f"Fetched {len(alma_items)} "
+        f"item{'s' if len(alma_items) > 1 else ''} from Alma"
+    )
+    # And reuse the `indicator_type_matching` logic again
+    alma_match_data, _ = get_alma_match_data(alma_items)
+
+    # Use the unmatched data to prepare the report rows
+    _, unmatched_data = match_containers(alma_match_data, aspace_match_data)
+    unmatched_alma_items = unmatched_data.get("unmatched_alma_items", [])
+    print(
+        f"Found {len(unmatched_alma_items)} "
+        f"Alma item{'s' if len(unmatched_alma_items) > 1 else ''} "
+        "without a matching ASpace top container"
+    )
+
+    # Write the CSV report
+    print(f"Writing CSV report to {args.output_path}")
+    rows = _prepare_report_rows(unmatched_alma_items, args.resource_id, args.bib_id)
+    output_path = Path(args.output_path)
+    _write_report_csv(output_path, rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/find_missing_containers_aspace.py
+++ b/python/find_missing_containers_aspace.py
@@ -1,12 +1,11 @@
 import argparse
-import csv
 from datetime import datetime
 
 from alma_api_client import AlmaAPIClient
 from asnake.client import ASnakeClient
 from pathlib import Path
 
-from utils import load_config
+from utils import load_config, write_dicts_to_csv
 from utils.alma_utils import get_alma_items_from_alma
 from utils.aspace_utils import get_container_refs_from_db
 
@@ -99,31 +98,6 @@ def _get_all_top_containers_for_resource(
             continue
         all_tcs.append(tc)
     return all_tcs
-
-
-def _write_report_csv(
-    output_path: Path,
-    rows: list[dict],
-) -> None:
-    """Write the CSV report to the given output path.
-
-    :param Path output_path: Path to write the CSV report.
-    :param list[dict] rows: A list of CSV row dictionaries.
-    """
-    fieldnames = [
-        "ASpace Resource ID",
-        "Alma Bib ID",
-        "Alma Item Barcode",
-        "Alma Box Identifier",
-        "ASpace Match Found",
-        "Notes",
-    ]
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=fieldnames)
-        writer.writeheader()
-        for row in rows:
-            writer.writerow(row)
 
 
 def _prepare_report_rows(
@@ -221,7 +195,7 @@ def main() -> None:
     print(f"Writing CSV report to {args.output_path}")
     rows = _prepare_report_rows(unmatched_alma_items, args.resource_id, args.bib_id)
     output_path = Path(args.output_path)
-    _write_report_csv(output_path, rows)
+    write_dicts_to_csv(output_path, rows)
 
 
 if __name__ == "__main__":

--- a/python/find_missing_containers_aspace.py
+++ b/python/find_missing_containers_aspace.py
@@ -1,5 +1,6 @@
 import argparse
 import csv
+from datetime import datetime
 
 from alma_api_client import AlmaAPIClient
 from asnake.client import ASnakeClient
@@ -61,8 +62,16 @@ def _get_args() -> argparse.Namespace:
         "-o",
         "--output_path",
         type=str,
-        required=True,
-        help="Path to write the CSV report.",
+        required=False,
+        default=(
+            f"reports/aspace_missing_containers_"
+            f"{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+            ".csv"
+        ),
+        help=(
+            "Path to write the CSV report. "
+            "Defaults to 'reports/aspace_missing_containers_<DATETIME>.csv'."
+        ),
     )
     return parser.parse_args()
 
@@ -199,6 +208,9 @@ def main() -> None:
     # Use the unmatched data to prepare the report rows
     _, unmatched_data = match_containers(alma_match_data, aspace_match_data)
     unmatched_alma_items = unmatched_data.get("unmatched_alma_items", [])
+    if not unmatched_alma_items:
+        print("No unmatched Alma items found. Exiting.")
+        return
     print(
         f"Found {len(unmatched_alma_items)} "
         f"Alma item{'s' if len(unmatched_alma_items) > 1 else ''} "

--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -4,6 +4,6 @@ Re-export generic utilities so they can be imported directly from the utils pack
 E.g. `from utils import configure_logging` vs `from utils.generic_utils import configure_logging`.
 """
 
-from .generic_utils import configure_logging, load_config
+from .generic_utils import configure_logging, load_config, write_dicts_to_csv
 
-__all__ = ["configure_logging", "load_config"]
+__all__ = ["configure_logging", "load_config", "write_dicts_to_csv"]

--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -4,6 +4,6 @@ Re-export generic utilities so they can be imported directly from the utils pack
 E.g. `from utils import configure_logging` vs `from utils.generic_utils import configure_logging`.
 """
 
-from .generic_utils import configure_logging
+from .generic_utils import configure_logging, load_config
 
-__all__ = ["configure_logging"]
+__all__ = ["configure_logging", "load_config"]

--- a/python/utils/alma_utils.py
+++ b/python/utils/alma_utils.py
@@ -1,0 +1,46 @@
+"""
+Utility functions and helpers for working with Alma.
+
+This module provides utilities for interacting with Alma
+that can be reused across multiple scripts in the toolkit.
+"""
+
+from alma_api_client import AlmaAPIClient
+
+
+def get_alma_items_from_alma(
+    alma_client: AlmaAPIClient, bib_id: str, holdings_id: str
+) -> list[dict]:
+    """Returns item data from Alma for the given bib_id and holdings_id.
+    The data is a list of dictionaries, each containing Alma data for one item.
+
+    :param alma_client: AlmaAPIClient instance.
+    :param str bib_id: Bib ID (AKA MMS ID) for the target collection.
+    :param str holdings_id: Holdings ID for the target collection.
+    :return: A list of dictionaries representing Alma items.
+    """
+    alma_items = []
+    offset = 0
+    # Get the total expected number of items
+    try:
+        response = alma_client.get_items(bib_id, holdings_id, {"limit": 1})
+        response.raise_for_status()
+        data = response.json()
+        total_items = data.get("total_record_count", 0)
+    except Exception as e:
+        raise ValueError(f"Failed to get items from Alma: {e}")
+
+    while len(alma_items) < total_items:
+        try:
+            response = alma_client.get_items(
+                bib_id, holdings_id, {"limit": 100, "offset": offset}
+            )
+            response.raise_for_status()
+            data = response.json()
+            items = data.get("item", [])
+        except Exception as e:
+            raise ValueError(f"Failed to get items from Alma: {e}")
+        for item in items:
+            alma_items.append(item.get("item_data"))
+        offset += 100
+    return alma_items

--- a/python/utils/generic_utils.py
+++ b/python/utils/generic_utils.py
@@ -1,6 +1,7 @@
 """Generic logging setup helpers for reuse across scripts."""
 
 import asnake.logging as logging
+import csv
 import yaml
 from datetime import datetime
 from pathlib import Path
@@ -27,3 +28,23 @@ def load_config(config_file: str) -> dict:
     """
     with open(config_file, "r") as f:
         return yaml.safe_load(f)
+
+
+def write_dicts_to_csv(
+    output_path: Path,
+    rows: list[dict],
+) -> None:
+    """Write a list of dictionaries to a CSV file,
+    with each dict representing a row in the CSV.
+    Fieldnames are derived from the first dict in the list.
+
+    :param Path output_path: Path to write the CSV file.
+    :param list[dict] rows: A list of CSV row dictionaries.
+    """
+    # Get the fieldnames from the first row
+    fieldnames = list(rows[0].keys())
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)

--- a/python/utils/generic_utils.py
+++ b/python/utils/generic_utils.py
@@ -1,6 +1,7 @@
 """Generic logging setup helpers for reuse across scripts."""
 
 import asnake.logging as logging
+import yaml
 from datetime import datetime
 from pathlib import Path
 
@@ -16,3 +17,13 @@ def configure_logging(log_filename_stem: str = "log") -> None:
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     log_filename = logs_dir / f"{log_filename_stem}_{timestamp}.log"
     logging.setup_logging(filename=log_filename, level="INFO")
+
+
+def load_config(config_file: str) -> dict:
+    """Load the configuration file and return the config dictionary.
+
+    :param str config_file: Path to YAML configuration file with connection details.
+    :return dict: Config dict.
+    """
+    with open(config_file, "r") as f:
+        return yaml.safe_load(f)


### PR DESCRIPTION
Implements [DLSR-305](https://uclalibrary.atlassian.net/browse/DLSR-305)

### Acceptance criteria
- [X] All Alma items for a given collection are evaluated against the ASpace top container list
- [X] Any Alma item whose box identifier does not match an ASpace top container is captured in the output report
- [X] No data is modified in Alma or ArchivesSpace
- [X] The report is produced as a CSV file
- [X] The script completes without error when a collection has zero discrepancies, producing an empty report or a summary confirmation

### Description
This PR adds `python/find_missing_containers_aspace.py`, a new script that compares top container type-indicator values from ArchivesSpace to corresponding item descriptions in Alma, then outputs a report of Alma items that have no matching top container in ArchivesSpace. Almost all the main business logic for the script is reused from `config.base_match` and `config.indicator_type_matching`, which we used in the barcoding script `add_alma_barcodes_to_archivesspace.py`.

The basic shape of the `get_alma_items_from_alma()` function was copied from `add_alma_barcodes_to_archivesspace.py` to a new utility module `utils/alma_utils.py`. However, due to changes to [alma-api-client](https://github.com/UCLALibrary/alma-api-client), this function had to be refactored a bit from how it's implemented in `add_alma_barcodes_to_archivesspace.py`.

I chose not to use a log file or log stream in this script, opting instead for simple print statements, since the output report provides the target information. I also chose to default to the database when retrieving ASpace top container refs, both to side-step the API timeout issue on larger collections and to keep usage consistent with `cleanup_compound_indicators_aspace.py` for LSC staff.

### Testing
No new unit tests are added. All 16 existing tests still pass.

To test manually, I used the following LSC collection:
| Identifier | Title | ASpace resource ID | Alma MMS ID | Alma holdings ID |
|--------|--------|--------|--------|--------|
| LSC.1550 | Leo Kuper papers | 692 | 9919730453606533 | 22529139550006533 |

The following command should yield a CSV report showing 1 mismatched box:
`python find_missing_containers_aspace.py -c .archivessnake_secret_DEV.yml -r 692 --bib_id 9919730453606533 --holdings_id 22529139550006533`

**Expected output**
```
ASpace Resource ID,Alma Bib ID,Alma Item Barcode,Alma Box Identifier,ASpace Match Found,Notes
692,9919730453606533,FF0000132035,box.51,No,No matching ASpace top container found — requires review
```

[DLSR-305]: https://uclalibrary.atlassian.net/browse/DLSR-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ