### PR TITLE
DLSR-351: Refactor scripts to use shared utilities

### DIFF
--- a/python/add_alma_barcodes_to_archivesspace.py
+++ b/python/add_alma_barcodes_to_archivesspace.py
@@ -396,7 +396,7 @@ def main() -> None:
 
     # For convenience while debugging, print log name without full container path.
     # Also used in names of some output files.
-    logging_filename_base = Path(logging.handler.baseFilename).stem
+    logging_filename_base = Path(__file__).stem
     print(f"Logging to {logging_filename_base}.log")
     configure_logging(log_filename_stem=logging_filename_base)
 

--- a/python/add_alma_barcodes_to_archivesspace.py
+++ b/python/add_alma_barcodes_to_archivesspace.py
@@ -397,7 +397,7 @@ def main() -> None:
     # For convenience while debugging, print log name without full container path.
     # Also used in names of some output files.
     logging_filename_base = Path(logging.handler.baseFilename).stem
-    print(f"Logging to logs/{logging_filename_base}.log")
+    print(f"Logging to {logging_filename_base}.log")
     configure_logging(log_filename_stem=logging_filename_base)
 
     args: argparse.Namespace = _get_args()

--- a/python/add_alma_barcodes_to_archivesspace.py
+++ b/python/add_alma_barcodes_to_archivesspace.py
@@ -8,7 +8,7 @@ from asnake.client import ASnakeClient
 import asnake.logging as logging
 
 from config.base_match import match_containers
-from utils import configure_logging, load_config
+from utils import configure_logging, load_config, read_from_cache, write_to_cache
 from utils.alma_utils import get_alma_items_from_alma
 from utils.aspace_utils import get_container_refs_from_api, get_container_refs_from_db
 
@@ -98,35 +98,6 @@ def _get_containers_from_container_refs(
     return containers
 
 
-def _get_cached_data_from_file(filename: str) -> list[dict] | None:
-    """Reads data from the given file and returns it.
-    For this project, data will be list[dict], but this method does not enforce that.
-
-    :param str filename: Filename of cache file.
-    :return: A list of Alma items.
-    """
-    data_file = Path(filename)
-    if data_file.exists():
-        logger.info(f"Reading alma data from {data_file}")
-        with open(data_file, "r") as f:
-            data = json.load(f)
-    else:
-        data = None
-    return data
-
-
-def _store_cached_data_in_file(data: list[dict], filename: str) -> None:
-    """Stores data in the given file for possible later use.
-    For this project, data will be list[dict], but this method does not enforce that.
-
-    :param list[dict] data: A list of Alma items.
-    :param str filename: Filename for cache file.
-    """
-    logger.info(f"Writing data to {filename}")
-    with open(filename, "w") as f:
-        json.dump(data, f)
-
-
 def get_alma_items(
     alma_client: AlmaAPIClient, bib_id: str, holdings_id: str, use_cache: bool
 ) -> list[dict]:
@@ -145,12 +116,14 @@ def get_alma_items(
     alma_cache_file = f"alma_data_{holdings_id}.json"
     # If using cache, get data from file if it exists.
     if use_cache:
-        alma_items = _get_cached_data_from_file(alma_cache_file)
+        logger.info(f"Reading Alma data from cache file {alma_cache_file}")
+        alma_items = read_from_cache(alma_cache_file)
     # If still no items, retrieve current data from Alma.
     if not alma_items:
         alma_items = get_alma_items_from_alma(alma_client, bib_id, holdings_id)
         # Cache data in file for possible later use.
-        _store_cached_data_in_file(alma_items, alma_cache_file)
+        logger.info(f"Caching Alma data in {alma_cache_file}")
+        write_to_cache(alma_items, alma_cache_file)
     return alma_items
 
 
@@ -176,7 +149,8 @@ def get_aspace_containers(
     aspace_cache_file = f"aspace_data_{resource_id}.json"
     # If using cache, get data from file if it exists.
     if use_cache:
-        containers = _get_cached_data_from_file(aspace_cache_file)
+        logger.info(f"Reading ASpace data from cache file {aspace_cache_file}")
+        containers = read_from_cache(aspace_cache_file)
     # If still no containers, retrieve current data from ASpace.
     if not containers:
         if use_db:
@@ -191,19 +165,10 @@ def get_aspace_containers(
         containers = _get_containers_from_container_refs(aspace_client, container_refs)
 
         # Cache data in file for possible later use.
-        _store_cached_data_in_file(containers, aspace_cache_file)
+        logger.info(f"Caching ASpace data in {aspace_cache_file}")
+        write_to_cache(containers, aspace_cache_file)
 
     return containers
-
-
-def write_json_to_file(data: dict, filename: str) -> None:
-    """Utility function for writing cache files.
-
-    :param dict data: A dict to write to a file.
-    :param str filename: Filename for output file.
-    """
-    with open(filename, "w") as f:
-        json.dump(data, f, indent=2)
 
 
 def print_unhandled_data(unhandled_data: dict) -> None:
@@ -524,7 +489,7 @@ def main() -> None:
     # if there is any unhandled data, write it to a file
     if unhandled_data:
         unhandled_data_filename = f"unhandled_{logging_filename_base}.json"
-        write_json_to_file(unhandled_data, unhandled_data_filename)
+        write_to_cache(unhandled_data, unhandled_data_filename, indent=2)
         logger.info(
             f"Unhandled data (items and top containers remaining unmatched or with duplicate keys)"
             f" written to {unhandled_data_filename}"

--- a/python/add_alma_barcodes_to_archivesspace.py
+++ b/python/add_alma_barcodes_to_archivesspace.py
@@ -1,37 +1,22 @@
 import argparse
 import json
-import yaml
-from datetime import datetime
+
 from importlib import import_module
 from pathlib import Path
 from alma_api_client import AlmaAPIClient
 from asnake.client import ASnakeClient
-from structlog.stdlib import BoundLogger  # for typehints
 import asnake.logging as logging
-from MySQLdb import connect
-from MySQLdb.cursors import DictCursor
+
 from config.base_match import match_containers
+from utils import configure_logging, load_config
+from utils.alma_utils import get_alma_items_from_alma
+from utils.aspace_utils import get_container_refs_from_api, get_container_refs_from_db
 
 
-def _get_logger(name: str | None = None) -> BoundLogger:
-    """Returns a logger for the current application. This is provided by
-    the asnake.logging package, which uses structlog.
-    A unique log filename is created using the current time, and log messages
-    will use the name in the 'logger' field.
-    If name not supplied, the name of the current script is used.
-
-    :param str name: Filename for the log. Defaults to None.
-    """
-    if not name:
-        # Use base filename of current script.
-        name = Path(__file__).stem
-    logs_dir = Path("logs")  # save logs to "./logs/"
-    logs_dir.mkdir(parents=True, exist_ok=True)  # create dir if it doesn't exist
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    logging_filename_base = f"{name}_{timestamp}"
-    logging_filename = logs_dir / f"{logging_filename_base}.log"
-    logging.setup_logging(filename=logging_filename, level="INFO")
-    return logging.get_logger(name=name)
+# Logger available globally within this module.
+# Configuration is done by configure_logging(), which is called by main().
+# Made available globally so that tests can use the same logger with their own configuration.
+logger = logging.get_logger(Path(__file__).stem)
 
 
 def _get_args() -> argparse.Namespace:
@@ -44,6 +29,12 @@ def _get_args() -> argparse.Namespace:
     parser.add_argument("--holdings_id", help="Alma holdings MMS ID", required=True)
     parser.add_argument(
         "--resource_id", help="ArchivesSpace resource ID", required=True
+    )
+    parser.add_argument(
+        "--repo_id",
+        help="ArchivesSpace repository ID. Defaults to 2.",
+        required=False,
+        default=2,
     )
     parser.add_argument("--profile", help="Path to profile module", required=True)
     parser.add_argument(
@@ -82,102 +73,6 @@ def _get_args() -> argparse.Namespace:
     )
     args = parser.parse_args()
     return args
-
-
-def _get_alma_api_key(config_file: str) -> str:
-    """Returns the Alma API key stored in the config file.
-
-    :param str config_file: YAML configuration file with connection details.
-    """
-    with open(config_file, "r") as f:
-        config = yaml.safe_load(f)
-    return config["alma_config"]["alma_api_key"]
-
-
-def _get_alma_items_from_alma(
-    alma_client: AlmaAPIClient, bib_id: str, holdings_id: str
-) -> list[dict]:
-    """Returns item data from Alma for the given bib_id and holdings_id.
-    The data is a list of dictionaries, each containing Alma data for one item.
-
-    :param alma_client: AlmaAPIClient instance.
-    :param str bib_id: Bib ID (AKA MMS ID) for the target collection.
-    :param str holdings_id: Holdiings ID for the target collection.
-    :return: A list of dictionaries representing Alma items.
-    """
-    alma_items = []
-    offset = 0
-    # get the total expected number of items
-    total_items = alma_client.get_items(bib_id, holdings_id, {"limit": 1}).get(
-        "total_record_count", 0
-    )
-    while len(alma_items) < total_items:
-        current_items = alma_client.get_items(
-            bib_id, holdings_id, {"limit": 100, "offset": offset}
-        )
-        offset += 100
-        # keep only item_data from each item in the list
-        for item in current_items.get("item", []):
-            alma_items.append(item.get("item_data"))
-    return alma_items
-
-
-def _get_container_refs_from_api(
-    aspace_client: ASnakeClient, resource_id: int
-) -> set[str]:
-    """Returns a de-duped set of _ref_ top container URIs for the given resource_id,
-    obtained via API call.
-    This API call can fail via timeout in hosted environments, when
-    more than a few thousand containers are associated with the resource.
-
-    :param ASnakeClient aspace_client: ASnakeClient instance.
-    :param int resource_id: ASpace resource ID for target collection.
-    :return: A set of container refs.
-    """
-    url = f"/repositories/2/resources/{resource_id}/top_containers"
-    container_refs = aspace_client.get(url).json()
-    # Extract the ref URIs and de-dup.
-    return set(tc["ref"] for tc in container_refs)
-
-
-def _get_container_refs_from_db(db_settings: dict, resource_id: int) -> set[str]:
-    """Returns a de-duped set of _ref_ top container URIs for the given resource_id,
-    obtained via database query.
-    This is intended as an alternative for resources with more than a few thousand
-    containers, as the API call may time out.
-
-    :param dict db_settings: A dict with DB connection details.
-    :param int resource_id: ASpace resource ID for target collection.
-    :return: A set of container refs.
-    """
-    mysql_client = connect(
-        host=db_settings.get("host"),
-        database=db_settings.get("database"),
-        user=db_settings.get("user"),
-        password=db_settings.get("password"),
-    )
-
-    query = """
-        select distinct
-            concat('/repositories/', r.repo_id, '/top_containers/', tc.id) as container_uri
-        from resource r
-        inner join archival_object ao on r.id = ao.root_record_id
-        inner join instance i on ao.id = i.archival_object_id
-        inner join sub_container sc on i.id = sc.instance_id
-        inner join top_container_link_rlshp tclr on sc.id = tclr.sub_container_id
-        inner join top_container tc on tclr.top_container_id = tc.id
-        where r.id = %s
-        and ao.publish = 1 -- true
-        and ao.suppressed = 0 -- false
-        order by container_uri
-    """
-    # Parameterized query requires tuple of values
-    cursor = mysql_client.cursor(DictCursor)
-    cursor.execute(query, (resource_id,))
-    container_refs = set(row["container_uri"] for row in cursor.fetchall())
-    cursor.close()
-    mysql_client.close()
-    return container_refs
 
 
 def _get_containers_from_container_refs(
@@ -253,20 +148,25 @@ def get_alma_items(
         alma_items = _get_cached_data_from_file(alma_cache_file)
     # If still no items, retrieve current data from Alma.
     if not alma_items:
-        alma_items = _get_alma_items_from_alma(alma_client, bib_id, holdings_id)
+        alma_items = get_alma_items_from_alma(alma_client, bib_id, holdings_id)
         # Cache data in file for possible later use.
         _store_cached_data_in_file(alma_items, alma_cache_file)
     return alma_items
 
 
 def get_aspace_containers(
-    aspace_client: ASnakeClient, resource_id: int, use_db: bool, use_cache: bool
+    aspace_client: ASnakeClient,
+    repo_id: int,
+    resource_id: int,
+    use_db: bool,
+    use_cache: bool,
 ) -> list[dict]:
     """Given a set of top container ref URIs, obtain the full container data as JSON
     for each one that linked to a published resource.
     Returns a list of qualifying container data.
 
     :param ASnakeClient aspace_client: ASnakeClient instance.
+    :param int repo_id: ASpace repository ID.
     :param int resource_id: ASpace resource ID for target collection.
     :param bool use_db: If True, get ASpace data from DB, otherwise get it via the API.
     :param bool use_cache: If True, get data from cache file, otherwise get it from Alma.
@@ -281,9 +181,11 @@ def get_aspace_containers(
     if not containers:
         if use_db:
             db_settings = aspace_client.config.get("database")
-            container_refs = _get_container_refs_from_db(db_settings, resource_id)
+            container_refs = get_container_refs_from_db(db_settings, resource_id)
         else:
-            container_refs = _get_container_refs_from_api(aspace_client, resource_id)
+            container_refs = get_container_refs_from_api(
+                aspace_client, repo_id, resource_id
+            )
 
         # The top containers endpoint returns refs, so we need to get the full container JSON.
         containers = _get_containers_from_container_refs(aspace_client, container_refs)
@@ -459,6 +361,7 @@ def _remove_barcodes_from_aspace(
         print("Retrieving container information from ASpace...")
         aspace_containers = get_aspace_containers(
             aspace_client=aspace_client,
+            repo_id=args.repo_id,
             resource_id=args.resource_id,
             use_db=args.use_db,
             use_cache=args.use_cache,
@@ -529,11 +432,15 @@ def main() -> None:
     # For convenience while debugging, print log name without full container path.
     # Also used in names of some output files.
     logging_filename_base = Path(logging.handler.baseFilename).stem
-    print(f"Logging to {logging_filename_base}.log")
+    print(f"Logging to logs/{logging_filename_base}.log")
+    configure_logging(log_filename_stem=logging_filename_base)
 
     args: argparse.Namespace = _get_args()
-    alma_client = AlmaAPIClient(_get_alma_api_key(config_file=args.config_file))
-    aspace_client = ASnakeClient(config_file=args.config_file)
+    config = load_config(args.config_file)
+    alma_api_key = config["alma_config"]["alma_api_key"]
+
+    alma_client = AlmaAPIClient(alma_api_key)
+    aspace_client = ASnakeClient(**config)
 
     # Require use of --undo_barcoding if --use_log is set
     if args.use_log and not args.undo_barcoding:
@@ -550,7 +457,7 @@ def main() -> None:
     logger.info(f"Found {len(alma_items)} items in Alma")
 
     aspace_containers = get_aspace_containers(
-        aspace_client, args.resource_id, args.use_db, args.use_cache
+        aspace_client, args.repo_id, args.resource_id, args.use_db, args.use_cache
     )
     logger.info(f"Found {len(aspace_containers)} top containers in ASpace")
 
@@ -625,7 +532,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    # Defining logger here makes it available to all code in this module.
-    logger = _get_logger()
-    # Finally, do everything
     main()

--- a/python/delete_unlinked_top_containers.py
+++ b/python/delete_unlinked_top_containers.py
@@ -4,14 +4,12 @@ import argparse
 
 from pathlib import Path
 
-from utils import configure_logging
+from utils import configure_logging, load_config
 
 # Logger available globally within this module.
 # Configuration is done by configure_logging(), which is called by main().
 # Made available globally so that tests can use the same logger with their own configuration.
 logger = logging.get_logger(Path(__file__).stem)
-
-client = ASnakeClient()
 
 
 def _get_args() -> argparse.Namespace:
@@ -21,13 +19,25 @@ def _get_args() -> argparse.Namespace:
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "container_list_file",
+        "-f",
+        "--container_list_file",
         help="Path to a file containing a list of top container URIs to delete",
+    )
+    parser.add_argument(
+        "-c",
+        "--config_file",
+        help="Path to a YAML configuration file with ArchivesSpace credentials",
+        required=True,
+    )
+    parser.add_argument(
+        "--dry_run",
+        action="store_true",
+        help="Log intended deletions without updating ArchivesSpace.",
     )
     return parser.parse_args()
 
 
-def container_is_unlinked(top_container_uri: str) -> bool:
+def container_is_unlinked(client: ASnakeClient, top_container_uri: str) -> bool:
     """Checks if a top container is unlinked by looking foran empty collection field.
 
     :param str top_container_uri: The URI of the top container to check.
@@ -37,7 +47,7 @@ def container_is_unlinked(top_container_uri: str) -> bool:
     return len(top_container["collection"]) == 0
 
 
-def container_has_errors(top_container_uri: str) -> bool:
+def container_has_errors(client: ASnakeClient, top_container_uri: str) -> bool:
     """Checks if a top container has errors by looking for an error key in the response.
 
     :param str top_container_uri: The URI of the top container to check.
@@ -52,10 +62,14 @@ def container_has_errors(top_container_uri: str) -> bool:
     return False
 
 
-def delete_unlinked_top_containers(container_list_file: str):
+def delete_unlinked_top_containers(
+    client: ASnakeClient, container_list_file: str, dry_run: bool
+):
     """Deletes unlinked top containers from an ASpace repository.
 
+    :param ASnakeClient client: ASnake client instance.
     :param str container_list_file: Path to file containing URIs of top containers to delete.
+    :param bool dry_run: If True, log intended deletions without updating ArchivesSpace.
     """
     logger.info(f"Reading top container URIs to delete from {container_list_file}")
     with open(container_list_file, "r") as f:
@@ -65,46 +79,58 @@ def delete_unlinked_top_containers(container_list_file: str):
     deleted_count = 0
     skipped_uri_list = []
     for container in container_list:
-        if container_has_errors(container):
+        if container_has_errors(client, container):
             # error message already logged in container_has_errors()
             skipped_uri_list.append(container)
             continue
-        if container_is_unlinked(container):
-            logger.info(f"Deleting unlinked top container: {container}")
-            delete_response = client.delete(container)
-            status_code = delete_response.status_code
-            if status_code == 200:
-                # All OK
-                deleted_count += 1
-            elif status_code == 403:
-                # Forbidden
-                logger.error(
-                    f"Permission denied deleting top container {container}:"
-                    f"{delete_response.json()}"
-                )
-                raise PermissionError(
-                    f"Permission denied deleting top container {container}"
-                )
+        if container_is_unlinked(client, container):
+            if dry_run:
+                logger.info(f"DRY RUN: Would delete unlinked top container {container}")
+                continue
             else:
-                # Unknown error
-                logger.error(
-                    f"Unknown error {status_code} deleting top container {container}:"
-                    f"{delete_response.json()}"
-                )
+                logger.info(f"Deleting unlinked top container: {container}")
+                delete_response = client.delete(container)
+                status_code = delete_response.status_code
+                if status_code == 200:
+                    # All OK
+                    deleted_count += 1
+                elif status_code == 403:
+                    # Forbidden
+                    logger.error(
+                        f"Permission denied deleting top container {container}:"
+                        f"{delete_response.json()}"
+                    )
+                    raise PermissionError(
+                        f"Permission denied deleting top container {container}"
+                    )
+                else:
+                    # Unknown error
+                    logger.error(
+                        f"Unknown error {status_code} deleting top container {container}:"
+                        f"{delete_response.json()}"
+                    )
         else:
             logger.info(
                 f"Top container {container} is linked to a collection. Skipping deletion."
             )
             skipped_uri_list.append(container)
-    logger.info(f"Deleted {deleted_count} top containers")
-    logger.info(f"Skipped {len(skipped_uri_list)} top containers: {skipped_uri_list}")
+    logger.info(
+        f"{'DRY RUN: Would delete' if dry_run else 'Deleted'} {deleted_count} top containers"
+    )
+    logger.info(
+        f"{'DRY RUN: Would skip' if dry_run else 'Skipped'} "
+        f"{len(skipped_uri_list)} top containers: {skipped_uri_list}"
+    )
 
 
 def main() -> None:
     """Deletes unlinked top containers from an ASpace repository."""
     configure_logging(Path(__file__).stem)
     args = _get_args()
-    delete_unlinked_top_containers(args.container_list_file)
+    config = load_config(args.config_file)
+    client = ASnakeClient(**config)
+
+    delete_unlinked_top_containers(client, args.container_list_file, args.dry_run)
 
 
 if __name__ == "__main__":

--- a/python/delete_unlinked_top_containers.py
+++ b/python/delete_unlinked_top_containers.py
@@ -2,18 +2,47 @@ import asnake.logging as logging
 from asnake.client import ASnakeClient
 import argparse
 
-logging.setup_logging(filename="archivessnake.log", level="INFO")
-# set label for custom logger - all output will be in archivessnake.log
-logger = logging.get_logger("delete_unlinked_top_containers")
+from pathlib import Path
+
+from utils import configure_logging
+
+# Logger available globally within this module.
+# Configuration is done by configure_logging(), which is called by main().
+# Made available globally so that tests can use the same logger with their own configuration.
+logger = logging.get_logger(Path(__file__).stem)
+
 client = ASnakeClient()
 
 
+def _get_args() -> argparse.Namespace:
+    """Returns the command-line arguments for this program.
+
+    :return: Parsed CLI arguments.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "container_list_file",
+        help="Path to a file containing a list of top container URIs to delete",
+    )
+    return parser.parse_args()
+
+
 def container_is_unlinked(top_container_uri: str) -> bool:
+    """Checks if a top container is unlinked by looking foran empty collection field.
+
+    :param str top_container_uri: The URI of the top container to check.
+    :return: True if the top container is unlinked, False otherwise.
+    """
     top_container = client.get(top_container_uri).json()
     return len(top_container["collection"]) == 0
 
 
 def container_has_errors(top_container_uri: str) -> bool:
+    """Checks if a top container has errors by looking for an error key in the response.
+
+    :param str top_container_uri: The URI of the top container to check.
+    :return: True if the top container has errors, False otherwise.
+    """
     top_container = client.get(top_container_uri).json()
     if "error" in top_container.keys():
         logger.error(
@@ -24,6 +53,10 @@ def container_has_errors(top_container_uri: str) -> bool:
 
 
 def delete_unlinked_top_containers(container_list_file: str):
+    """Deletes unlinked top containers from an ASpace repository.
+
+    :param str container_list_file: Path to file containing URIs of top containers to delete.
+    """
     logger.info(f"Reading top container URIs to delete from {container_list_file}")
     with open(container_list_file, "r") as f:
         container_list = f.readlines()
@@ -67,12 +100,12 @@ def delete_unlinked_top_containers(container_list_file: str):
     logger.info(f"Skipped {len(skipped_uri_list)} top containers: {skipped_uri_list}")
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "container_list_file",
-        help="Path to a file containing a list of top container URIs to delete",
-    )
-    args = parser.parse_args()
-
+def main() -> None:
+    """Deletes unlinked top containers from an ASpace repository."""
+    configure_logging(Path(__file__).stem)
+    args = _get_args()
     delete_unlinked_top_containers(args.container_list_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/delete_unlinked_top_containers.py
+++ b/python/delete_unlinked_top_containers.py
@@ -86,6 +86,7 @@ def delete_unlinked_top_containers(
         if container_is_unlinked(client, container):
             if dry_run:
                 logger.info(f"DRY RUN: Would delete unlinked top container {container}")
+                deleted_count += 1
                 continue
             else:
                 logger.info(f"Deleting unlinked top container: {container}")

--- a/python/find_duplicate_indicators.py
+++ b/python/find_duplicate_indicators.py
@@ -1,30 +1,15 @@
 import argparse
-from datetime import datetime
-from pathlib import Path
-from asnake.client import ASnakeClient
-from structlog.stdlib import BoundLogger  # for typehints
 import asnake.logging as logging
-import csv
-import yaml
 
+from asnake.client import ASnakeClient
+from pathlib import Path
 
-def _get_logger(name: str | None = None) -> BoundLogger:
-    """Returns a logger for the current application. This is provided by
-    the asnake.logging package, which uses structlog.
-    A unique log filename is created using the current time, and log messages
-    will use the name in the 'logger' field.
-    If name not supplied, the name of the current script is used.
+from utils import configure_logging, load_config, write_dicts_to_csv
 
-    :param str name: Filename for the log. Defaults to None.
-    """
-    if not name:
-        # Use base filename of current script.
-        name = Path(__file__).stem
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    logging_filename_base = f"{name}_{timestamp}"
-    logging_filename = f"{logging_filename_base}.log"
-    logging.setup_logging(filename=logging_filename, level="INFO")
-    return logging.get_logger(name=name)
+# Logger available globally within this module.
+# Configuration is done by configure_logging(), which is called by main().
+# Made available globally so that tests can use the same logger with their own configuration.
+logger = logging.get_logger(Path(__file__).stem)
 
 
 def _get_args() -> argparse.Namespace:
@@ -177,19 +162,7 @@ def write_duplicates_to_file(
         # Concatenate location names into a single string for easier reading in the CSV.
         item["locations"] = "; ".join(item["locations"])
 
-    with open(filename, "w", newline="") as csvfile:
-        fieldnames = [
-            "collection",
-            "type",
-            "indicator",
-            "container_uri",
-            "tc_link",
-            "locations",
-        ]
-        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-        writer.writeheader()
-        for item in duplicates:
-            writer.writerow(item)
+    write_dicts_to_csv(Path(filename), duplicates)
 
 
 def format_tc_uri_as_link(uri: str, base_url: str) -> str:
@@ -210,14 +183,13 @@ def format_tc_uri_as_link(uri: str, base_url: str) -> str:
 
 
 def remove_backlog_containers_from_list(
-    aspace_client: ASnakeClient, duplicates: list, logger: BoundLogger
+    aspace_client: ASnakeClient, duplicates: list
 ) -> list[dict]:
     """Given a list of top containers, removes any that are linked to Archival Objects
     with "backlog material" in the title.
 
     :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
     :param list duplicates: A list of Top Container URIs to check.
-    :param BoundLogger logger: A logger instance for logging messages.
     """
     filtered_duplicates = []
     for uri in duplicates:
@@ -233,14 +205,13 @@ def remove_backlog_containers_from_list(
 
 
 def main() -> None:
+    configure_logging(Path(__file__).stem)
     args = _get_args()
-    logger = _get_logger()
 
     # Get URL info from config file, and initialize client
-    with open(args.config_file, "r") as f:
-        config = yaml.safe_load(f)
-        base_url = config.get("baseurl")
-    aspace_client = ASnakeClient(config_file=args.config_file)
+    config = load_config(args.config_file)
+    base_url = config.get("baseurl", "")
+    aspace_client = ASnakeClient(**config)
 
     # Check that provided start, end, and specific collection IDs make sense together.
     # If collection_id is provided, we should not have start_collection_id or end_collection_id.
@@ -311,7 +282,7 @@ def main() -> None:
                 # Only check for backlog material if we have more than one container
                 # with the same indicator/type to avoid unnecessary API calls.
                 indicator_type_pairs_seen[key] = remove_backlog_containers_from_list(
-                    aspace_client, container_uri_list, logger
+                    aspace_client, container_uri_list
                 )
 
         for (

--- a/python/get_container_counts.py
+++ b/python/get_container_counts.py
@@ -1,8 +1,10 @@
 from asnake.client import ASnakeClient
-from add_alma_barcodes_to_archivesspace import _get_container_refs_from_db
 import argparse
 import csv
 from pathlib import Path
+
+from utils import write_dicts_to_csv
+from utils.aspace_utils import get_container_refs_from_db
 
 
 def _get_args() -> argparse.Namespace:
@@ -48,10 +50,8 @@ def main() -> None:
                 try:
                     resource_id = int(row["ArchivesSpace Rec ID"])
                     # Counting container refs, rather than getting all container data
-                    container_refs = (
-                        _get_container_refs_from_db(  # imported from existing script
-                            db_settings, resource_id
-                        )
+                    container_refs = get_container_refs_from_db(
+                        db_settings, resource_id
                     )
                     row["container_count"] = len(container_refs)
                     rows_updated_with_counts += 1
@@ -69,11 +69,7 @@ def main() -> None:
 
     output_filename = Path(args.file_name).stem + "_with_container_counts.csv"
     print(f"Writing counts to {output_filename}...")
-    with open(output_filename, "w+", newline="", encoding="utf-8") as output_file:
-        fieldnames = data_with_counts[0].keys()
-        writer = csv.DictWriter(output_file, fieldnames)
-        writer.writeheader()
-        writer.writerows(data_with_counts)
+    write_dicts_to_csv(Path(output_filename), data_with_counts)
 
 
 if __name__ == "__main__":

--- a/python/get_unlinked_top_containers.py
+++ b/python/get_unlinked_top_containers.py
@@ -1,14 +1,38 @@
-import asnake.logging as logging
-from asnake.client import ASnakeClient
 import argparse
+import asnake.logging as logging
 
-logging.setup_logging(filename="archivessnake.log", level="INFO")
-# set label for custom logger - all output will be in archivessnake.log
-logger = logging.get_logger("get_unlinked_top_containers")
+from asnake.client import ASnakeClient
+from pathlib import Path
+from utils import configure_logging
+
+# Logger available globally within this module.
+# Configuration is done by configure_logging(), which is called by main().
+# Made available globally so that tests can use the same logger with their own configuration.
+logger = logging.get_logger(Path(__file__).stem)
+
 client = ASnakeClient()
 
 
+def _get_args() -> argparse.Namespace:
+    """Returns the command-line arguments for this program.
+
+    :return: Parsed CLI arguments.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--page_size",
+        help="Number of records to retrieve per page",
+        default=250,
+        type=int,
+    )
+    return parser.parse_args()
+
+
 def get_unlinked_top_containers(page_size: int = 250):
+    """Retrieves all unlinked top containers from an ASpace repository and writes them to a file.
+
+    :param int page_size: Number of records to retrieve per page.
+    """
 
     output_list = []
     for top_container in client.get_paged(
@@ -26,14 +50,11 @@ def get_unlinked_top_containers(page_size: int = 250):
     logger.info("Output written to unlinked_top_containers.txt")
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--page_size",
-        help="Number of records to retrieve per page",
-        default=250,
-        type=int,
-    )
-    args = parser.parse_args()
-
+def main() -> None:
+    configure_logging(Path(__file__).stem)
+    args = _get_args()
     get_unlinked_top_containers(args.page_size)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/get_unlinked_top_containers.py
+++ b/python/get_unlinked_top_containers.py
@@ -3,14 +3,12 @@ import asnake.logging as logging
 
 from asnake.client import ASnakeClient
 from pathlib import Path
-from utils import configure_logging
+from utils import configure_logging, load_config
 
 # Logger available globally within this module.
 # Configuration is done by configure_logging(), which is called by main().
 # Made available globally so that tests can use the same logger with their own configuration.
 logger = logging.get_logger(Path(__file__).stem)
-
-client = ASnakeClient()
 
 
 def _get_args() -> argparse.Namespace:
@@ -20,6 +18,26 @@ def _get_args() -> argparse.Namespace:
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "-c",
+        "--config_file",
+        help="Path to a YAML configuration file with ArchivesSpace credentials",
+        required=True,
+    )
+    parser.add_argument(
+        "--repo_id",
+        help="ArchivesSpace repository ID to target. Defaults to 2.",
+        required=False,
+        type=int,
+        default=2,
+    )
+    parser.add_argument(
+        "-o",
+        "--output_file",
+        help="Path to a file to write the output to. Defaults to unlinked_top_containers.txt.",
+        required=False,
+        default="unlinked_top_containers.txt",
+    )
+    parser.add_argument(
         "--page_size",
         help="Number of records to retrieve per page",
         default=250,
@@ -28,15 +46,20 @@ def _get_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def get_unlinked_top_containers(page_size: int = 250):
+def get_unlinked_top_containers(
+    client: ASnakeClient, repo_id: int, output_file: str, page_size: int = 250
+):
     """Retrieves all unlinked top containers from an ASpace repository and writes them to a file.
 
+    :param ASnakeClient client: ASnake client instance.
+    :param int repo_id: ArchivesSpace repository ID to target.
+    :param str output_file: Path to a file to write the output to.
     :param int page_size: Number of records to retrieve per page.
     """
 
     output_list = []
     for top_container in client.get_paged(
-        "repositories/2/top_containers", page_size=page_size
+        f"repositories/{repo_id}/top_containers", page_size=page_size
     ):
         # unlinked top containers have an empty collection field
         if len(top_container["collection"]) == 0:
@@ -44,16 +67,20 @@ def get_unlinked_top_containers(page_size: int = 250):
             output_list.append(top_container["uri"])
 
     logger.info(f"Total unlinked top containers: {len(output_list)}")
-    with open("unlinked_top_containers.txt", "w") as f:
+    with open(output_file, "w") as f:
         for item in output_list:
             f.write(f"{item}\n")
-    logger.info("Output written to unlinked_top_containers.txt")
+    logger.info(f"Output written to {output_file}")
 
 
 def main() -> None:
+    """Retrieves all unlinked top containers from an ASpace repository and writes them to a file."""
     configure_logging(Path(__file__).stem)
     args = _get_args()
-    get_unlinked_top_containers(args.page_size)
+    config = load_config(args.config_file)
+    client = ASnakeClient(**config)
+
+    get_unlinked_top_containers(client, args.repo_id, args.output_file, args.page_size)
 
 
 if __name__ == "__main__":

--- a/python/tests/test_container_retrieval.py
+++ b/python/tests/test_container_retrieval.py
@@ -1,8 +1,8 @@
 import unittest
 from asnake.client import ASnakeClient
-from add_alma_barcodes_to_archivesspace import (
-    _get_container_refs_from_api,
-    _get_container_refs_from_db,
+from utils.aspace_utils import (
+    get_container_refs_from_api,
+    get_container_refs_from_db,
 )
 
 
@@ -14,8 +14,9 @@ class TestContainerRetrieval(unittest.TestCase):
         cls.db_settings = cls.aspace_client.config.get("database")
 
     def test_retrievals_are_identical(self):
+        repo_id = 2
         resource_id = 3002  # should have just a few top containers
-        api_refs = _get_container_refs_from_api(self.aspace_client, resource_id)
-        db_refs = _get_container_refs_from_db(self.db_settings, resource_id)
+        api_refs = get_container_refs_from_api(self.aspace_client, repo_id, resource_id)
+        db_refs = get_container_refs_from_db(self.db_settings, resource_id)
         # Don't check sizes as local data can change, but confirm the values are the same.
         self.assertEqual(api_refs, db_refs)

--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -4,6 +4,18 @@ Re-export generic utilities so they can be imported directly from the utils pack
 E.g. `from utils import configure_logging` vs `from utils.generic_utils import configure_logging`.
 """
 
-from .generic_utils import configure_logging, load_config, write_dicts_to_csv
+from .generic_utils import (
+    configure_logging,
+    load_config,
+    write_dicts_to_csv,
+    read_from_cache,
+    write_to_cache,
+)
 
-__all__ = ["configure_logging", "load_config", "write_dicts_to_csv"]
+__all__ = [
+    "configure_logging",
+    "load_config",
+    "write_dicts_to_csv",
+    "read_from_cache",
+    "write_to_cache",
+]

--- a/python/utils/generic_utils.py
+++ b/python/utils/generic_utils.py
@@ -2,6 +2,7 @@
 
 import asnake.logging as logging
 import csv
+import json
 import yaml
 from datetime import datetime
 from pathlib import Path
@@ -48,3 +49,38 @@ def write_dicts_to_csv(
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(rows)
+
+
+def read_from_cache(filename: str) -> list[dict] | None:
+    """Reads data from the given file and returns it.
+    Data is expected to be a list of dictionaries,
+    but this method does not enforce that.
+
+    :param str filename: Filename of cache file.
+    :return: A list of Alma items, or None if the cache file does not exist.
+    """
+    data_file = Path(filename)
+    if data_file.exists():
+        with open(data_file, "r") as f:
+            data = json.load(f)
+    else:
+        data = None
+    return data
+
+
+def write_to_cache(
+    data: dict | list[dict],
+    filename: str,
+    indent: int | None = None,
+) -> None:
+    """Stores data in the given file for possible later use.
+    Data is expected to be a dict or list of dicts,
+    but this method does not enforce that.
+
+    :param dict | list[dict] data: Data to write to the cache file.
+    :param str filename: Filename for cache file.
+    :param int indent: Number of spaces to indent the JSON data.
+        Defaults to None, which means no indentation.
+    """
+    with open(filename, "w") as f:
+        json.dump(data, f, indent=indent)

--- a/python/utils/generic_utils.py
+++ b/python/utils/generic_utils.py
@@ -1,4 +1,4 @@
-"""Generic logging setup helpers for reuse across scripts."""
+"""Generic utility functions for reuse across scripts."""
 
 import asnake.logging as logging
 import csv
@@ -57,7 +57,7 @@ def read_from_cache(filename: str) -> list[dict] | None:
     but this method does not enforce that.
 
     :param str filename: Filename of cache file.
-    :return: A list of Alma items, or None if the cache file does not exist.
+    :return: A list of dictionaries, or None if the cache file does not exist.
     """
     data_file = Path(filename)
     if data_file.exists():


### PR DESCRIPTION
Implements [DLSR-351](https://uclalibrary.atlassian.net/browse/DLSR-351)

### Acceptance criteria
- [X] Scripts are refactored to use shared code within the local `utils` package

### Description
This PR refactors the scripts under the `python` directory to use shared code that was moved into `python/utils` in #23 and #24. Much of the refactoring has to do with logging, loading config, or writing output to CSV files. Other changes include doc-string updates and general maintenance to match our latest code style.

### Testing
All 16 unit tests in the project still pass: `python -m unittest` from within the `python` container. 


[DLSR-351]: https://uclalibrary.atlassian.net/browse/DLSR-351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ