### PR TITLE
DLSR-260: Add script to merge duplicate top containers

### DIFF
--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -129,7 +129,8 @@ def _has_location_data(tcs: list[dict]) -> bool:
         locations = tc.get("container_locations", [])
         if locations:
             logger.warning(
-                f"Top container {tc.get('uri')} has location data: {locations}"
+                f"Top container {tc.get('uri')} has location data: "
+                f"{[location.get('ref') for location in locations]}"
             )
             return True
     return False

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -110,11 +110,12 @@ def _resolve_ao_refs_for_tcs(
     return tcs
 
 
-def _check_for_location_data(tcs: list[dict]) -> None:
+def _has_location_data(tcs: list[dict]) -> bool:
     """Check for location data on a list of top container records
     representing a duplicate group, flagging the group for review if found.
 
     :param list[dict] tcs: List of top container records representing a duplicate group.
+    :return: True if any top container has location data, False otherwise.
     """
     for tc in tcs:
         locations = tc.get("container_locations", [])
@@ -122,6 +123,8 @@ def _check_for_location_data(tcs: list[dict]) -> None:
             logger.warning(
                 f"Top container {tc.get('uri')} has location data: {locations}"
             )
+            return True
+    return False
 
 
 def _has_recent_accession_keywords(tcs: list[dict]) -> bool:
@@ -223,6 +226,40 @@ def _merge_top_containers(
     return True
 
 
+def _print_summary(summary: dict, dry_run: bool) -> None:
+    """Add summary info to the log and print a friendly message to the console.
+
+    :param dict summary: Dict containing summary info for the run.
+    :param bool dry_run: If True, print a dry run report.
+    """
+    if dry_run:
+        lines = [
+            f"{'*' * 5} DRY RUN SUMMARY {'*' * 5}",
+            f"Total duplicate groups: {summary['Total duplicate groups']}",
+            f"Groups with location data: {summary['Groups with location data']}",
+            (
+                f"Groups with recent accession keywords:"
+                f" {summary['Groups with recent accession keywords']}"
+            ),
+        ]
+    else:
+        lines = [
+            f"{'*' * 5} SUMMARY {'*' * 5}",
+            f"Total duplicate groups: {summary['Total duplicate groups']}",
+            f"Groups with location data: {summary['Groups with location data']}",
+            (
+                f"Groups with recent accession keywords:"
+                f" {summary['Groups with recent accession keywords']}"
+            ),
+            f"Successful merges: {summary['Successful merges']}",
+            f"Failed merges: {summary['Failed merges']}",
+        ]
+    lines.append(f"{'*' * len(lines[0])}")
+    for line in lines:
+        print(line)
+        logger.info(line)
+
+
 def _process_duplicates_in_collection(
     aspace_client: ASnakeClient,
     db_config: dict,
@@ -255,9 +292,10 @@ def _process_duplicates_in_collection(
 
     summary = {
         "Total duplicate groups": len(duplicate_groups),
+        "Groups with location data": 0,
+        "Groups with recent accession keywords": 0,
         "Successful merges": 0,
         "Failed merges": 0,
-        "Groups requiring manual review": 0,
     }
     for type, indicator, tcs in duplicate_groups:
         logger.info(
@@ -268,8 +306,9 @@ def _process_duplicates_in_collection(
         # Check for any location data in the duplicate group.
         # Per ticket, this should not stop processing,
         # but should be logged for visibility in dry run mode.
-        if dry_run:
-            _check_for_location_data(tcs)
+        if dry_run and _has_location_data(tcs):
+            summary["Groups with location data"] += 1
+            continue
 
         # Resolve AO refs to their full dictionaries
         # to make it easier to check AO titles for recent accession keywords
@@ -278,7 +317,7 @@ def _process_duplicates_in_collection(
         # Check for recent accession keywords in the titles of related archival objects
         # in the duplicate group, and stop processing the group if any are found.
         if _has_recent_accession_keywords(tcs):
-            summary["Groups requiring manual review"] += 1
+            summary["Groups with recent accession keywords"] += 1
             continue
 
         canonical_tc, duplicate_tcs = _determine_canonical_tc(tcs)
@@ -297,9 +336,7 @@ def _process_duplicates_in_collection(
             continue
         summary["Successful merges"] += 1
 
-    logger.info("Finished merging duplicate top containers")
-    for key, value in summary.items():
-        logger.info(f"{key}: {value}")
+    _print_summary(summary, dry_run)
 
 
 def main() -> None:

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -280,15 +280,28 @@ def _process_duplicates_in_collection(
         5. Delete the duplicate top container(s).
     """
     tcs_by_indicator = _get_tcs_by_indicator(aspace_client, db_config, resource_id)
-    # Find TC records that have duplicate (type, indicator) keys
+    # Group TC records by (type, indicator) keys
     duplicate_groups: list[tuple[str, str, list[dict]]] = [
         (type, indicator, tcs)
         for (type, indicator), tcs in tcs_by_indicator.items()
         if len(tcs) > 1
     ]
+    # If no duplicate groups are found, log a note and return
     if not duplicate_groups:
         logger.info(f"No duplicate top containers found for Resource ID {resource_id}.")
         return
+
+    # Now sort the duplicate groups alphabetically by type and numerically by indicator,
+    # to make review of the logs easier.
+    duplicate_groups = sorted(
+        duplicate_groups,
+        key=lambda group: (
+            group[0],  # sort alphabetically by type
+            (
+                int(group[1]) if group[1].isdigit() else group[1]
+            ),  # then numerically by indicator, if possible
+        ),
+    )
 
     summary = {
         "Total duplicate groups": len(duplicate_groups),

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -2,6 +2,7 @@ import argparse
 
 from asnake import logging
 from asnake.client import ASnakeClient
+from asnake.jsonmodel import JM
 from collections import defaultdict
 from pathlib import Path
 
@@ -28,6 +29,13 @@ def _get_args() -> argparse.Namespace:
         type=str,
         required=True,
         help="Path to YAML config file with ArchivesSpace credentials.",
+    )
+    parser.add_argument(
+        "--repo_id",
+        type=int,
+        required=False,
+        default=2,
+        help="ArchivesSpace repository ID to target. Defaults to 2.",
     )
     parser.add_argument(
         "-r",
@@ -164,101 +172,76 @@ def _determine_canonical_tc(tcs: list[dict]) -> tuple[dict, list[dict]]:
     return canonical, [tc for tc in tcs if tc is not canonical]
 
 
-def _relink_archival_object_instances(
-    archival_object: dict,
-    source_tc_uri: str,
-    target_tc_uri: str,
-) -> dict:
-    """Relink archival object instances from source to target top container.
-
-    :param dict archival_object: The archival object dict to update.
-    :param str source_tc_uri: The URI of the source top container.
-    :param str target_tc_uri: The URI of the target top container.
-    :return: The updated archival object dict.
-    """
-    for instance in archival_object.get("instances", []):
-        sub_container = instance.get("sub_container", {})
-        top_container = sub_container.get("top_container", {})
-        if top_container.get("ref", "") == source_tc_uri:
-            instance["sub_container"]["top_container"]["ref"] = target_tc_uri
-    return archival_object
-
-
-def _handle_duplicate_top_containers(
+def _merge_top_containers(
     aspace_client: ASnakeClient,
     canonical_tc: dict,
     duplicate_tcs: list[dict],
+    repo_id: int,
     dry_run: bool,
-) -> None:
-    """Handle duplicate top containers by relinking related archival objects
-    to the canonical top container, then deleting the duplicate top containers.
+) -> bool:
+    """Merge duplicate top containers into the canonical top container
+    using the `/merge_requests/top_container` endpoint of the ArchivesSpace API.
+
+    NOTE: The ArchivesSpace API endpoint used in this function is sparsely documented here:
+    @https://archivesspace.github.io/archivesspace/api/?python#carry-out-a-merge-request-against-top-container-records
+    From manual testing, it appears to manage relinking of related archival objects
+    aggregating them all to point to the canonical top container,
+    then deleting the TCs identified in the request as duplicates (i.e. the `merge_candidates`).
 
     :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
-    :param dict canonical_tc: The canonical top container dict.
-    :param list[dict] duplicate_tcs: The duplicate top container dicts.
-    :param bool dry_run: If True, log the intended updates without updating.
+    :param dict canonical_tc: The canonical top container record.
+    :param list[dict] duplicate_tcs: The duplicate top container records.
+    :param int repo_id: The ArchivesSpace repository ID.
+    :param bool dry_run: If True, log the intended action without making the API call.
+    :return: True if the merge request is successful, False otherwise.
     """
-    for duplicate_tc in duplicate_tcs:
-        logger.info(f"Processing duplicate top container '{duplicate_tc['uri']}'...")
-        logger.info(
-            f"Found {len(duplicate_tc['_related_aos_temp'])} linked archival object(s)..."
-        )
+    # The `JM` helper class provides an easy way
+    # to construct json payload for the request.
+    request_body = JM.merge_requests(
+        uri="/merge_requests/top_container",
+        merge_destination={"ref": canonical_tc["uri"]},
+        merge_candidates=[{"ref": tc["uri"]} for tc in duplicate_tcs],
+    )
 
-        # Relink each archival object from duplicate to canonical top container
-        for original_ao in duplicate_tc["_related_aos_temp"]:
-            ao_ref = original_ao["uri"]
-            logger.info(
-                f"{'DRY RUN: Would relink' if dry_run else 'Relinking'} "
-                f"archival object '{original_ao['uri']}' "
-                f"from '{duplicate_tc['uri']}' to '{canonical_tc['uri']}'"
+    logger.info(
+        f"{'DRY RUN: Would merge' if dry_run else 'Merging'} "
+        f"duplicate top containers {[tc['uri'] for tc in duplicate_tcs]} "
+        f"into canonical top container '{canonical_tc['uri']}'"
+    )
+
+    if not dry_run:
+        try:
+            response = aspace_client.post(
+                "/merge_requests/top_container",
+                params={"repo_id": repo_id},
+                json=request_body,
             )
-
-            updated_ao = _relink_archival_object_instances(
-                original_ao, duplicate_tc["uri"], canonical_tc["uri"]
-            )
-
-            if original_ao != updated_ao:
-                print(updated_ao)
-                if dry_run:
-                    logger.info(
-                        f"DRY RUN: Would apply updates " f"to instance(s) on {ao_ref}"
-                    )
-                else:
-                    try:
-                        response = aspace_client.post(ao_ref, json=updated_ao)
-                        response.raise_for_status()
-                    except Exception as err:
-                        logger.error(
-                            f"Error updating archival object {ao_ref}: {err}. Skipping."
-                        )
-                        continue
-                    logger.info(f"Applied updates to instance(s) on {ao_ref}")
-
-        # Delete duplicate top container after relinking archival objects
-        if dry_run:
-            logger.info(
-                f"DRY RUN: Would delete duplicate top container '{duplicate_tc['uri']}'"
-            )
-        else:
-            try:
-                response = aspace_client.delete(duplicate_tc["uri"])
-                response.raise_for_status()
-            except Exception as err:
-                logger.error(
-                    f"Error deleting duplicate top container "
-                    f"{duplicate_tc['uri']}: {err}. Skipping."
-                )
-                continue
-            logger.info(f"Deleted duplicate top container '{duplicate_tc['uri']}'")
+            response.raise_for_status()
+        except Exception as err:
+            logger.error(f"Error merging duplicate top containers: {err}. Skipping.")
+            return False
+    return True
 
 
-def _merge_duplicate_containers(
+def _process_duplicates_in_collection(
     aspace_client: ASnakeClient,
     db_config: dict,
+    repo_id: int,
     resource_id: int,
     dry_run: bool,
 ) -> None:
-    """Merge duplicate top containers in ArchivesSpace."""
+    """Merge duplicate top containers in ArchivesSpace,
+    for a given collection (identified by `resource_id`).
+
+    Summary of LSC ticket:
+        1. Retrieve all top containers in the collection.
+        2. Identify duplicate groups by type and indicator.
+        3. For each group, designate a canonical top container,
+        based on criteria provided by LSC.
+        4. Merge the duplicate top containers into the canonical top container,
+        preserving archival object links in the process.
+        5. Delete the duplicate top container(s).
+    """
     tcs_by_indicator = _get_tcs_by_indicator(aspace_client, db_config, resource_id)
     # Find TC records that have duplicate (type, indicator) keys
     duplicate_groups: list[tuple[str, str, list[dict]]] = [
@@ -270,6 +253,12 @@ def _merge_duplicate_containers(
         logger.info(f"No duplicate top containers found for Resource ID {resource_id}.")
         return
 
+    summary = {
+        "Total duplicate groups": len(duplicate_groups),
+        "Successful merges": 0,
+        "Failed merges": 0,
+        "Groups requiring manual review": 0,
+    }
     for type, indicator, tcs in duplicate_groups:
         logger.info(
             f"Found {len(tcs)} top containers "
@@ -289,7 +278,8 @@ def _merge_duplicate_containers(
         # Check for recent accession keywords in the titles of related archival objects
         # in the duplicate group, and stop processing the group if any are found.
         if _has_recent_accession_keywords(tcs):
-            return
+            summary["Groups requiring manual review"] += 1
+            continue
 
         canonical_tc, duplicate_tcs = _determine_canonical_tc(tcs)
 
@@ -299,25 +289,21 @@ def _merge_duplicate_containers(
             f"{[tc['uri'] for tc in duplicate_tcs]}"
         )
 
-        _handle_duplicate_top_containers(
-            aspace_client, canonical_tc, duplicate_tcs, dry_run
+        success = _merge_top_containers(
+            aspace_client, canonical_tc, duplicate_tcs, repo_id, dry_run
         )
+        if not success:
+            summary["Failed merges"] += 1
+            continue
+        summary["Successful merges"] += 1
 
     logger.info("Finished merging duplicate top containers")
+    for key, value in summary.items():
+        logger.info(f"{key}: {value}")
 
 
 def main() -> None:
-    """Merge duplicate top containers in ArchivesSpace,
-    for a given resource (i.e. collection).
-
-    Summary of LSC ticket:
-    1. Retrieve all top containers in the collection.
-    2. Identify duplicate groups by type and indicator.
-    3. For each group, designate a canonical top container,
-      based on criteria provided by LSC.
-    4. Relink archival objects to the canonical top container.
-    5. Delete the duplicate top container(s).
-    """
+    """Entry-point for this program."""
     args = _get_args()
     configure_logging(Path(__file__).stem, args.dry_run)
     config = load_config(args.config_file)
@@ -326,8 +312,8 @@ def main() -> None:
         raise ValueError("DB connection settings are required.")
     aspace_client = ASnakeClient(**config)
 
-    _merge_duplicate_containers(
-        aspace_client, db_config, args.resource_id, args.dry_run
+    _process_duplicates_in_collection(
+        aspace_client, db_config, args.repo_id, args.resource_id, args.dry_run
     )
 
 

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -1,11 +1,12 @@
 import argparse
+
+from asnake import logging
 from asnake.client import ASnakeClient
-from asnake.logging import get_logger
 from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
 
-from utils import configure_logging, load_config
+from utils import configure_logging, configure_console_logging, load_config
 from utils.aspace_utils import (
     get_container_refs_from_db,
     get_ao_refs_for_top_container_from_db,
@@ -14,7 +15,7 @@ from utils.aspace_utils import (
 # Logger available globally within this module.
 # Configuration is done by configure_logging(), which is called by main().
 # Made available globally so that tests can use the same logger with their own configuration.
-logger = get_logger(Path(__file__).stem)
+logger = logging.get_logger(Path(__file__).stem)
 
 
 def _get_args() -> argparse.Namespace:
@@ -69,17 +70,6 @@ def _get_tcs_by_indicator(
         indicator = tc.get("indicator", "")
         tcs_by_indicator[(type, indicator)].append(tc)
     return tcs_by_indicator
-
-
-def _count_ao_refs_for_tc(tc: dict, db_config: dict) -> int:
-    """Count the number of archival object references for a top container.
-
-    :param dict tc: Top container record.
-    :param dict db_config: DB connection settings.
-    :return: The number of archival object references for the top container.
-    """
-    tc_id = int(tc.get("uri", "0").split("/")[-1])
-    return len(get_ao_refs_for_top_container_from_db(db_config, tc_id))
 
 
 def _determine_canonical_tc(tcs: list[dict]) -> tuple[dict, list[dict]]:
@@ -183,8 +173,12 @@ def main() -> None:
     4. Relink archival objects to the canonical top container.
     5. Delete the duplicate top container(s).
     """
-    configure_logging(Path(__file__).stem)
     args = _get_args()
+    # Log dry run messages to console for better readability
+    if args.dry_run:
+        configure_console_logging()
+    else:
+        configure_logging(Path(__file__).stem)
     config = load_config(args.config_file)
     db_config = config.get("database")
     if not db_config:

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -375,8 +375,8 @@ def main() -> None:
     args = _get_args()
 
     log_filename_stem = Path(__file__).stem
-    print(f"Logging to {log_filename_stem}.log")
-    configure_logging(log_filename_stem, args.dry_run)
+    log_filename = configure_logging(log_filename_stem, args.dry_run)
+    print(f"Logging to {log_filename}...")
 
     config = load_config(args.config_file)
     db_config = config.get("database")

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -53,12 +53,12 @@ def _get_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _get_tcs_by_indicator(
+def _get_tcs_grouped_by_type_and_indicator(
     aspace_client: ASnakeClient,
     db_config: dict,
     resource_id: int,
 ) -> defaultdict[tuple[str, str], list[dict]]:
-    """Get all top containers in the collection grouped by (type, indicator).
+    """Get all top containers in the resource grouped by (type, indicator).
 
     :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
     :param dict db_config: DB connection settings.
@@ -72,7 +72,9 @@ def _get_tcs_by_indicator(
     )
 
     # Group top containers by (type, indicator) to identify duplicates
-    tcs_by_indicator: defaultdict[tuple[str, str], list[dict]] = defaultdict(list)
+    tcs_grouped_by_type_and_indicator: defaultdict[tuple[str, str], list[dict]] = (
+        defaultdict(list)
+    )
     for ref in container_refs:
         try:
             response = aspace_client.get(ref)
@@ -83,8 +85,8 @@ def _get_tcs_by_indicator(
             continue
         type = tc.get("type", "")
         indicator = tc.get("indicator", "")
-        tcs_by_indicator[(type, indicator)].append(tc)
-    return tcs_by_indicator
+        tcs_grouped_by_type_and_indicator[(type, indicator)].append(tc)
+    return tcs_grouped_by_type_and_indicator
 
 
 def _resolve_aos_for_tcs(
@@ -117,10 +119,10 @@ def _resolve_aos_for_tcs(
 
 
 def _has_location_data(tcs: list[dict]) -> bool:
-    """Check for location data on a list of top container records
-    representing a duplicate group, flagging the group for review if found.
+    """Check for location data on a list of top container records,
+    logging a warning and returning True if found, False otherwise.
 
-    :param list[dict] tcs: List of top container records representing a duplicate group.
+    :param list[dict] tcs: List of top container records.
     :return: True if any top container has location data, False otherwise.
     """
     for tc in tcs:
@@ -134,11 +136,10 @@ def _has_location_data(tcs: list[dict]) -> bool:
 
 
 def _has_recent_accession_keywords(tcs: list[dict]) -> bool:
-    """Within a top container duplicate group, check for recent accession keywords
-    in the titles of related archival objects,
+    """Check for recent accession keywords in archival objects titles,
     logging a warning and returning True if found, False otherwise.
 
-    :param list[dict] tcs: List of top container records representing a duplicate group.
+    :param list[dict] tcs: List of top container records.
     :return: True if any recent accession keywords are found, False otherwise.
     """
     recent_accession_keywords = ["accession", "backlog"]
@@ -147,11 +148,7 @@ def _has_recent_accession_keywords(tcs: list[dict]) -> bool:
             if any(
                 keyword in ao["title"].lower() for keyword in recent_accession_keywords
             ):
-                logger.warning(
-                    f"Archival object '{ao['uri']}' linked to top container '{tc['uri']}' "
-                    f"may be recent accession: "
-                    f"title='{ao['title']}'. Manual review of duplicate group required."
-                )
+                logger.warning("Manual review required")
                 return True
     return False
 
@@ -168,13 +165,13 @@ def _determine_canonical_tc(tcs: list[dict]) -> tuple[dict, list[dict]]:
     # Had help from LLM for this concise implementation.
     # Selects the minimum value of the tuple returned by the lambda function,
     # which is the TC with the most related archival objects (i.e. smallest negative value)
-    # or the oldest `create_time` if there are ties in the AO counts.
+    # or the earliest (i.e. minimum) `create_time` if there are ties in the AO counts.
     canonical = min(
         tcs,
         key=lambda tc: (
-            -len(tc["_related_aos_temp"]),
+            -len(tc.get("_related_aos_temp", [])),
             # If a TC is missing the `create_time` field,
-            # default to a future date so it sorts after TCs with a create time
+            # default to a value that sorts after TCs with a create time
             tc.get("create_time", "9999-01-01T00:00:00Z"),
         ),
     )
@@ -238,32 +235,65 @@ def _print_summary(summary: dict, dry_run: bool) -> None:
     :param dict summary: Dict containing summary info for the run.
     :param bool dry_run: If True, print a dry run report.
     """
-    if dry_run:
-        lines = [
-            f"{'*' * 5} DRY RUN SUMMARY {'*' * 5}",
-            f"Total duplicate groups: {summary['Total duplicate groups']}",
-            f"Groups with location data: {summary['Groups with location data']}",
-            (
-                f"Groups with recent accession keywords:"
-                f" {summary['Groups with recent accession keywords']}"
-            ),
-        ]
-    else:
-        lines = [
-            f"{'*' * 5} SUMMARY {'*' * 5}",
-            f"Total duplicate groups: {summary['Total duplicate groups']}",
-            f"Groups with location data: {summary['Groups with location data']}",
-            (
-                f"Groups with recent accession keywords:"
-                f" {summary['Groups with recent accession keywords']}"
-            ),
-            f"Successful merges: {summary['Successful merges']}",
-            f"Failed merges: {summary['Failed merges']}",
-        ]
+    lines = [
+        f"{'*' * 5} {'DRY RUN' if dry_run else ''} SUMMARY {'*' * 5}",
+        f"Total duplicate groups: {summary['Total duplicate groups']}",
+        f"Groups with location data: {summary['Groups with location data']}",
+        (
+            f"Groups with recent accession keywords:"
+            f" {summary['Groups with recent accession keywords']}"
+        ),
+    ]
+    # Add additional success/failure info if in production mode
+    if not dry_run:
+        lines.extend(
+            [
+                f"Successful merges: {summary['Successful merges']}",
+                f"Failed merges: {summary['Failed merges']}",
+            ]
+        )
     lines.append(f"{'*' * len(lines[0])}")
     for line in lines:
         print(line)
         logger.info(line)
+
+
+def _get_duplicate_groups(
+    aspace_client: ASnakeClient,
+    db_config: dict,
+    resource_id: int,
+) -> list[tuple[str, str, list[dict]]]:
+    """Retrieve top containers in the resource
+    and identify duplicate groups as those with the same type and indicator.
+
+    :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
+    :param dict db_config: DB connection settings.
+    :param int resource_id: The ID of the resource to process.
+    :return: A list of tuples representing duplicate groups,
+    comprising type, indicator, and a list of top container records.
+    """
+    tcs_grouped_by_type_and_indicator = _get_tcs_grouped_by_type_and_indicator(
+        aspace_client, db_config, resource_id
+    )
+
+    duplicate_groups: list[tuple[str, str, list[dict]]] = [
+        (type, indicator, tcs)
+        for (type, indicator), tcs in tcs_grouped_by_type_and_indicator.items()
+        if len(tcs) > 1
+    ]
+    # Now sort the duplicate groups,
+    # alphabetically by type and numerically by indicator,
+    # to make review of the logs easier.
+    duplicate_groups = sorted(
+        duplicate_groups,
+        key=lambda group: (
+            group[0],  # sort alphabetically by type
+            (
+                int(group[1]) if group[1].isdigit() else group[1]
+            ),  # then numerically by indicator, if possible
+        ),
+    )
+    return duplicate_groups
 
 
 def _process_duplicates_in_collection(
@@ -285,29 +315,11 @@ def _process_duplicates_in_collection(
         preserving archival object links in the process.
         5. Delete the duplicate top container(s).
     """
-    tcs_by_indicator = _get_tcs_by_indicator(aspace_client, db_config, resource_id)
-    # Group TC records by (type, indicator) keys
-    duplicate_groups: list[tuple[str, str, list[dict]]] = [
-        (type, indicator, tcs)
-        for (type, indicator), tcs in tcs_by_indicator.items()
-        if len(tcs) > 1
-    ]
+    duplicate_groups = _get_duplicate_groups(aspace_client, db_config, resource_id)
     # If no duplicate groups are found, log a note and return
     if not duplicate_groups:
         logger.info(f"No duplicate top containers found for Resource ID {resource_id}.")
         return
-
-    # Now sort the duplicate groups alphabetically by type and numerically by indicator,
-    # to make review of the logs easier.
-    duplicate_groups = sorted(
-        duplicate_groups,
-        key=lambda group: (
-            group[0],  # sort alphabetically by type
-            (
-                int(group[1]) if group[1].isdigit() else group[1]
-            ),  # then numerically by indicator, if possible
-        ),
-    )
 
     summary = {
         "Total duplicate groups": len(duplicate_groups),
@@ -323,11 +335,10 @@ def _process_duplicates_in_collection(
         )
 
         # Check for any location data in the duplicate group.
-        # Per ticket, this should not stop processing,
-        # but should be logged for visibility in dry run mode.
-        if dry_run and _has_location_data(tcs):
+        # Per ticket, this should not stop processing (no `continue` statement)
+        # but should be logged for visibility.
+        if _has_location_data(tcs):
             summary["Groups with location data"] += 1
-            continue
 
         # Resolve AO refs to their full dictionaries
         # to make it easier to check AO titles for recent accession keywords
@@ -336,6 +347,7 @@ def _process_duplicates_in_collection(
         # Check for recent accession keywords in the titles of related archival objects
         # in the duplicate group, and stop processing the group if any are found.
         if _has_recent_accession_keywords(tcs):
+            logger.warning("Found recent accession keywords in archival objects titles")
             summary["Groups with recent accession keywords"] += 1
             continue
 

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -3,10 +3,9 @@ import argparse
 from asnake import logging
 from asnake.client import ASnakeClient
 from collections import defaultdict
-from copy import deepcopy
 from pathlib import Path
 
-from utils import configure_logging, configure_console_logging, load_config
+from utils import configure_logging, load_config
 from utils.aspace_utils import (
     get_container_refs_from_db,
     get_ao_refs_for_top_container_from_db,
@@ -62,7 +61,9 @@ def _get_tcs_by_indicator(
     tcs_by_indicator: defaultdict[tuple[str, str], list[dict]] = defaultdict(list)
     for ref in container_refs:
         try:
-            tc = aspace_client.get(ref).json()
+            response = aspace_client.get(ref)
+            response.raise_for_status()
+            tc = response.json()
         except Exception as err:
             logger.error(f"Error fetching top container {ref}: {err}. Skipping.")
             continue
@@ -72,23 +73,89 @@ def _get_tcs_by_indicator(
     return tcs_by_indicator
 
 
+def _resolve_ao_refs_for_tcs(
+    aspace_client: ASnakeClient, db_config: dict, tcs: list[dict]
+) -> list[dict]:
+    """Resolve archival object refs to archival object dicts for a list of top container records.
+
+    :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
+    :param dict db_config: DB connection settings.
+    :param list[dict] tcs: List of top container records.
+    :return: A list of top container records
+        with related archival object dicts stored in a temporary field.
+    """
+    for tc in tcs:
+        tc["_related_aos_temp"] = []
+        tc_id = int(tc.get("uri", "0").split("/")[-1])
+        ao_refs = get_ao_refs_for_top_container_from_db(db_config, tc_id)
+        for ao_ref in ao_refs:
+            try:
+                response = aspace_client.get(ao_ref)
+                response.raise_for_status()
+                archival_object = response.json()
+                tc["_related_aos_temp"].append(archival_object)
+            except Exception as err:
+                logger.error(
+                    f"Error fetching archival object {ao_ref}: {err}. Skipping."
+                )
+                continue
+    return tcs
+
+
+def _check_for_location_data(tcs: list[dict]) -> None:
+    """Check for location data on a list of top container records
+    representing a duplicate group, flagging the group for review if found.
+
+    :param list[dict] tcs: List of top container records representing a duplicate group.
+    """
+    for tc in tcs:
+        locations = tc.get("container_locations", [])
+        if locations:
+            logger.warning(
+                f"Top container {tc.get('uri')} has location data: {locations}"
+            )
+
+
+def _has_recent_accession_keywords(tcs: list[dict]) -> bool:
+    """Within a top container duplicate group, check for recent accession keywords
+    in the titles of related archival objects,
+    logging a warning and returning True if found, False otherwise.
+
+    :param list[dict] tcs: List of top container records representing a duplicate group.
+    :return: True if any recent accession keywords are found, False otherwise.
+    """
+    recent_accession_keywords = ["accession", "backlog"]
+    for tc in tcs:
+        for ao in tc["_related_aos_temp"]:
+            if any(
+                keyword in ao["title"].lower() for keyword in recent_accession_keywords
+            ):
+                logger.warning(
+                    f"Archival object '{ao['uri']}' linked to top container '{tc['uri']}' "
+                    f"may be recent accession: "
+                    f"title='{ao['title']}'. Manual review of duplicate group required."
+                )
+                return True
+    return False
+
+
 def _determine_canonical_tc(tcs: list[dict]) -> tuple[dict, list[dict]]:
     """Determine the canonical top container from a list of top container records.
 
-    Uses the record with the most `ao_refs`,
-    or the oldest `create_time` if there are ties.
+    Uses the record with the most related archival objects,
+    or the oldest creation time if there are ties.
 
     :param list[dict] tcs: List of top container records.
     :return: A tuple of the canonical top container and the remaining duplicate TCs.
     """
     # Had help from LLM for this concise implementation.
     # Selects the minimum value of the tuple returned by the lambda function,
-    # which is the TC with the most `ao_refs` (i.e. smallest negative value)
+    # which is the TC with the most related archival objects (i.e. smallest negative value)
     # or the oldest `create_time` if there are ties in the AO counts.
     canonical = min(
         tcs,
         key=lambda tc: (
-            -len(tc["ao_refs"]),
+            -len(tc["_related_aos_temp"]),
             # If a TC is missing the `create_time` field,
             # default to a future date so it sorts after TCs with a create time
             tc.get("create_time", "9999-01-01T00:00:00Z"),
@@ -97,58 +164,91 @@ def _determine_canonical_tc(tcs: list[dict]) -> tuple[dict, list[dict]]:
     return canonical, [tc for tc in tcs if tc is not canonical]
 
 
-def _update_archival_object(
-    aspace_client: ASnakeClient,
-    ao_ref: str,
-    ao_body: dict,
-    dry_run: bool,
-) -> None:
-    """Update an archival object in ArchivesSpace."""
-    if not dry_run:
-        aspace_client.post(ao_ref, json=ao_body).json()
-    logger.info(
-        f"{'DRY RUN: Would update' if dry_run else 'Updated'} "
-        f"instance(s) on archival object {ao_ref}"
-    )
+def _relink_archival_object_instances(
+    archival_object: dict,
+    source_tc_uri: str,
+    target_tc_uri: str,
+) -> dict:
+    """Relink archival object instances from source to target top container.
+
+    :param dict archival_object: The archival object dict to update.
+    :param str source_tc_uri: The URI of the source top container.
+    :param str target_tc_uri: The URI of the target top container.
+    :return: The updated archival object dict.
+    """
+    for instance in archival_object.get("instances", []):
+        sub_container = instance.get("sub_container", {})
+        top_container = sub_container.get("top_container", {})
+        if top_container.get("ref", "") == source_tc_uri:
+            instance["sub_container"]["top_container"]["ref"] = target_tc_uri
+    return archival_object
 
 
-def _relink_archival_objects(
+def _handle_duplicate_top_containers(
     aspace_client: ASnakeClient,
     canonical_tc: dict,
     duplicate_tcs: list[dict],
     dry_run: bool,
 ) -> None:
-    """Relink archival objects from duplicates to the canonical top container."""
+    """Handle duplicate top containers by relinking related archival objects
+    to the canonical top container, then deleting the duplicate top containers.
+
+    :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
+    :param dict canonical_tc: The canonical top container dict.
+    :param list[dict] duplicate_tcs: The duplicate top container dicts.
+    :param bool dry_run: If True, log the intended updates without updating.
+    """
     for duplicate_tc in duplicate_tcs:
-        for ao_ref in duplicate_tc["ao_refs"]:
-            archival_object = aspace_client.get(ao_ref).json()
-            title = archival_object.get("title", "")
-            # If any archival object in the group contains "backlog" or "accession" in its title,
-            # log a message and skip merging the duplicate group.
-            if ["backlog", "accession"] in title.lower():
-                logger.info(
-                    f"Found archival object indicating new accession or accrual: {ao_ref}."
-                    "Manual review required."
-                )
-                return
-            original_instances = archival_object.get("instances", [])
-            if not original_instances:
-                continue
-            # Create a deep copy for comparison below
-            new_instances = deepcopy(original_instances)
-            for instance in new_instances:
-                sub_container = instance.get("sub_container", {})
-                top_container = sub_container.get("top_container", {})
-                # Overwrite the ref to the duplicate TC with the canonical TC
-                if top_container.get("ref", "") == duplicate_tc.get("uri"):
-                    instance["sub_container"]["top_container"]["ref"] = (
-                        canonical_tc.get("uri")
+        logger.info(f"Processing duplicate top container '{duplicate_tc['uri']}'...")
+        logger.info(
+            f"Found {len(duplicate_tc['_related_aos_temp'])} linked archival object(s)..."
+        )
+
+        # Relink each archival object from duplicate to canonical top container
+        for original_ao in duplicate_tc["_related_aos_temp"]:
+            ao_ref = original_ao["uri"]
+            logger.info(
+                f"{'DRY RUN: Would relink' if dry_run else 'Relinking'} "
+                f"archival object '{original_ao['uri']}' "
+                f"from '{duplicate_tc['uri']}' to '{canonical_tc['uri']}'"
+            )
+
+            updated_ao = _relink_archival_object_instances(
+                original_ao, duplicate_tc["uri"], canonical_tc["uri"]
+            )
+
+            if original_ao != updated_ao:
+                if dry_run:
+                    logger.info(
+                        f"DRY RUN: Would apply updates " f"to instance(s) on {ao_ref}"
                     )
-            # If the instances have changed, update the AO in ArchivesSpace,
-            # or log the intended update if dry_run
-            if original_instances != new_instances:
-                archival_object["instances"] = new_instances
-                _update_archival_object(aspace_client, ao_ref, archival_object, dry_run)
+                else:
+                    try:
+                        response = aspace_client.post(ao_ref, json=updated_ao)
+                        response.raise_for_status()
+                    except Exception as err:
+                        logger.error(
+                            f"Error updating archival object {ao_ref}: {err}. Skipping."
+                        )
+                        continue
+                    logger.info(f"Applied updates to instance(s) on {ao_ref}")
+
+        # Delete duplicate top container after relinking archival objects
+        if dry_run:
+            logger.info(
+                f"DRY RUN: Would delete duplicate top container '{duplicate_tc['uri']}'"
+            )
+        else:
+            try:
+                response = aspace_client.delete(duplicate_tc["uri"])
+                response.raise_for_status()
+            except Exception as err:
+                logger.error(
+                    f"Error deleting duplicate top container "
+                    f"{duplicate_tc['uri']}: {err}. Skipping."
+                )
+                continue
+            logger.info(f"Deleted duplicate top container '{duplicate_tc['uri']}'")
 
 
 def _merge_duplicate_containers(
@@ -175,18 +275,34 @@ def _merge_duplicate_containers(
             f"with type '{type}' and indicator '{indicator}'"
         )
 
-        # Add temporary field to each TC to store list of archival objects refs,
-        # and log locations if dry run
-        for tc in tcs:
-            locations = tc.get("container_locations", [])
-            if dry_run and locations:
-                logger.info(f"Top container {tc.get('uri')} has locations: {locations}")
-            tc_id = int(tc.get("uri", "0").split("/")[-1])
-            tc["ao_refs"] = get_ao_refs_for_top_container_from_db(db_config, tc_id)
+        # Check for any location data in the duplicate group.
+        # Per ticket, this should not stop processing,
+        # but should be logged for visibility in dry run mode.
+        if dry_run:
+            _check_for_location_data(tcs)
+
+        # Resolve AO refs to their full dictionaries
+        # to make it easier to check AO titles for recent accession keywords
+        # on the whole top container group at once.
+        tcs = _resolve_ao_refs_for_tcs(aspace_client, db_config, tcs)
+        # Check for recent accession keywords in the titles of related archival objects
+        # in the duplicate group, and stop processing the group if any are found.
+        if _has_recent_accession_keywords(tcs):
+            return
 
         canonical_tc, duplicate_tcs = _determine_canonical_tc(tcs)
 
-        _relink_archival_objects(aspace_client, canonical_tc, duplicate_tcs, dry_run)
+        logger.info(
+            f"Identified canonical top container '{canonical_tc['uri']}' "
+            f"and {len(duplicate_tcs)} duplicate top container(s): "
+            f"{[tc['uri'] for tc in duplicate_tcs]}"
+        )
+
+        _handle_duplicate_top_containers(
+            aspace_client, canonical_tc, duplicate_tcs, dry_run
+        )
+
+    logger.info("Finished merging duplicate top containers")
 
 
 def main() -> None:
@@ -202,11 +318,7 @@ def main() -> None:
     5. Delete the duplicate top container(s).
     """
     args = _get_args()
-    # Log dry run messages to console for better readability
-    if args.dry_run:
-        configure_console_logging()
-    else:
-        configure_logging(Path(__file__).stem)
+    configure_logging(Path(__file__).stem, args.dry_run)
     config = load_config(args.config_file)
     db_config = config.get("database")
     if not db_config:

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -2,6 +2,7 @@ import argparse
 from asnake.client import ASnakeClient
 from asnake.logging import get_logger
 from collections import defaultdict
+from copy import deepcopy
 from pathlib import Path
 
 from utils import configure_logging, load_config
@@ -34,6 +35,12 @@ def _get_args() -> argparse.Namespace:
         type=int,
         required=True,
         help="ArchivesSpace resource ID to process.",
+    )
+    parser.add_argument(
+        "-d",
+        "--dry_run",
+        action="store_true",
+        help="Run in dry run mode, without making any changes to ArchivesSpace.",
     )
     return parser.parse_args()
 
@@ -81,28 +88,74 @@ def _determine_canonical_tc(tcs: list[dict]) -> tuple[dict, list[dict]]:
     :param list[dict] tcs: List of top container records.
     :return: A tuple of the canonical top container and the remaining duplicate TCs.
     """
+    sorted_by_ao_count = sorted(tcs, key=lambda tc: len(tc["ao_refs"]), reverse=True)
+    return sorted_by_ao_count[0], sorted_by_ao_count[1:]
 
-    canonical_tc = max(tcs, key=_count_ao_refs_for_tc)
+
+def _update_archival_object(
+    aspace_client: ASnakeClient,
+    ao_ref: str,
+    ao_body: dict,
+    dry_run: bool,
+) -> None:
+    """Update an archival object in ArchivesSpace."""
+    if not dry_run:
+        aspace_client.post(ao_ref, json=ao_body).json()
+    logger.info(
+        f"{'DRY RUN: Would update' if dry_run else 'Updated'} "
+        f"instance(s) on archival object {ao_ref}"
+    )
+
+
+def _relink_archival_objects(
+    aspace_client: ASnakeClient,
+    canonical_tc: dict,
+    duplicate_tcs: list[dict],
+    dry_run: bool,
+) -> None:
+    """Relink archival objects from duplicates to the canonical top container."""
+    for duplicate_tc in duplicate_tcs:
+        for ao_ref in duplicate_tc["ao_refs"]:
+            archival_object = aspace_client.get(ao_ref).json()
+            original_instances = archival_object.get("instances", [])
+            if not original_instances:
+                continue
+            # Create a deep copy for comparison below
+            new_instances = deepcopy(original_instances)
+            for instance in new_instances:
+                sub_container = instance.get("sub_container", {})
+                top_container = sub_container.get("top_container", {})
+                # Overwrite the ref to the duplicate TC with the canonical TC
+                if top_container.get("ref", "") == duplicate_tc.get("uri"):
+                    instance["sub_container"]["top_container"]["ref"] = (
+                        canonical_tc.get("uri")
+                    )
+            # If the instances have changed, update the AO in ArchivesSpace,
+            # or log the intended update if dry_run
+            if original_instances != new_instances:
+                archival_object["instances"] = new_instances
+                _update_archival_object(aspace_client, ao_ref, archival_object, dry_run)
 
 
 def _merge_duplicate_containers(
     aspace_client: ASnakeClient,
     db_config: dict,
     resource_id: int,
+    dry_run: bool,
 ) -> None:
     """Merge duplicate top containers in ArchivesSpace."""
     tcs_by_indicator = _get_tcs_by_indicator(aspace_client, db_config, resource_id)
     # Find TC records that have duplicate (type, indicator) keys
-    duplicate_tcs: list[tuple[str, str, list[dict]]] = [
+    duplicate_groups: list[tuple[str, str, list[dict]]] = [
         (type, indicator, tcs)
         for (type, indicator), tcs in tcs_by_indicator.items()
         if len(tcs) > 1
     ]
-    if not duplicate_tcs:
+    if not duplicate_groups:
         logger.info("No duplicate top containers found for Resource ID {resource_id}.")
         return
 
-    for type, indicator, tcs in duplicate_tcs:
+    for type, indicator, tcs in duplicate_groups:
         logger.info(
             f"Found {len(tcs)} top containers "
             f"with type '{type}' and indicator '{indicator}'"
@@ -112,6 +165,10 @@ def _merge_duplicate_containers(
         for tc in tcs:
             tc_id = int(tc.get("uri", "0").split("/")[-1])
             tc["ao_refs"] = get_ao_refs_for_top_container_from_db(db_config, tc_id)
+
+        canonical_tc, duplicate_tcs = _determine_canonical_tc(tcs)
+
+        _relink_archival_objects(aspace_client, canonical_tc, duplicate_tcs, dry_run)
 
 
 def main() -> None:
@@ -134,7 +191,9 @@ def main() -> None:
         raise ValueError("DB connection settings are required.")
     aspace_client = ASnakeClient(**config)
 
-    _merge_duplicate_containers(aspace_client, db_config, args.resource_id)
+    _merge_duplicate_containers(
+        aspace_client, db_config, args.resource_id, args.dry_run
+    )
 
 
 if __name__ == "__main__":

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -89,8 +89,8 @@ def _determine_canonical_tc(tcs: list[dict]) -> tuple[dict, list[dict]]:
         tcs,
         key=lambda tc: (
             -len(tc["ao_refs"]),
-            # If missing `create_time`,
-            # treat as in future so it sorts after TC with create time
+            # If a TC is missing the `create_time` field,
+            # default to a future date so it sorts after TCs with a create time
             tc.get("create_time", "9999-01-01T00:00:00Z"),
         ),
     )

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -361,7 +361,11 @@ def _process_duplicates_in_collection(
 def main() -> None:
     """Entry-point for this program."""
     args = _get_args()
-    configure_logging(Path(__file__).stem, args.dry_run)
+
+    log_filename_stem = Path(__file__).stem
+    print(f"Logging to {log_filename_stem}.log")
+    configure_logging(log_filename_stem, args.dry_run)
+
     config = load_config(args.config_file)
     db_config = config.get("database")
     if not db_config:

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -1,0 +1,141 @@
+import argparse
+from asnake.client import ASnakeClient
+from asnake.logging import get_logger
+from collections import defaultdict
+from pathlib import Path
+
+from utils import configure_logging, load_config
+from utils.aspace_utils import (
+    get_container_refs_from_db,
+    get_ao_refs_for_top_container_from_db,
+)
+
+# Logger available globally within this module.
+# Configuration is done by configure_logging(), which is called by main().
+# Made available globally so that tests can use the same logger with their own configuration.
+logger = get_logger(Path(__file__).stem)
+
+
+def _get_args() -> argparse.Namespace:
+    """Get command-line arguments for this program."""
+    parser = argparse.ArgumentParser(
+        description="Merge duplicate top containers in ArchivesSpace."
+    )
+    parser.add_argument(
+        "-c",
+        "--config_file",
+        type=str,
+        required=True,
+        help="Path to YAML config file with ArchivesSpace credentials.",
+    )
+    parser.add_argument(
+        "-r",
+        "--resource_id",
+        type=int,
+        required=True,
+        help="ArchivesSpace resource ID to process.",
+    )
+    return parser.parse_args()
+
+
+def _get_tcs_by_indicator(
+    aspace_client: ASnakeClient,
+    db_config: dict,
+    resource_id: int,
+) -> defaultdict[tuple[str, str], list[dict]]:
+    """Get all top containers in the collection."""
+    container_refs = get_container_refs_from_db(db_config, resource_id)
+    logger.info(
+        f"Fetched {len(container_refs)} container{'s' if len(container_refs) > 1 else ''} "
+        f"for resource ID {resource_id}"
+    )
+
+    # Group top containers by (type, indicator) to identify duplicates
+    tcs_by_indicator: defaultdict[tuple[str, str], list[dict]] = defaultdict(list)
+    for ref in container_refs:
+        try:
+            tc = aspace_client.get(ref).json()
+        except Exception as err:
+            logger.error(f"Error fetching top container {ref}: {err}. Skipping.")
+            continue
+        type = tc.get("type", "")
+        indicator = tc.get("indicator", "")
+        tcs_by_indicator[(type, indicator)].append(tc)
+    return tcs_by_indicator
+
+
+def _count_ao_refs_for_tc(tc: dict, db_config: dict) -> int:
+    """Count the number of archival object references for a top container.
+
+    :param dict tc: Top container record.
+    :param dict db_config: DB connection settings.
+    :return: The number of archival object references for the top container.
+    """
+    tc_id = int(tc.get("uri", "0").split("/")[-1])
+    return len(get_ao_refs_for_top_container_from_db(db_config, tc_id))
+
+
+def _determine_canonical_tc(tcs: list[dict]) -> tuple[dict, list[dict]]:
+    """Determine the canonical top container from a list of top container records.
+
+    :param list[dict] tcs: List of top container records.
+    :return: A tuple of the canonical top container and the remaining duplicate TCs.
+    """
+
+    canonical_tc = max(tcs, key=_count_ao_refs_for_tc)
+
+
+def _merge_duplicate_containers(
+    aspace_client: ASnakeClient,
+    db_config: dict,
+    resource_id: int,
+) -> None:
+    """Merge duplicate top containers in ArchivesSpace."""
+    tcs_by_indicator = _get_tcs_by_indicator(aspace_client, db_config, resource_id)
+    # Find TC records that have duplicate (type, indicator) keys
+    duplicate_tcs: list[tuple[str, str, list[dict]]] = [
+        (type, indicator, tcs)
+        for (type, indicator), tcs in tcs_by_indicator.items()
+        if len(tcs) > 1
+    ]
+    if not duplicate_tcs:
+        logger.info("No duplicate top containers found for Resource ID {resource_id}.")
+        return
+
+    for type, indicator, tcs in duplicate_tcs:
+        logger.info(
+            f"Found {len(tcs)} top containers "
+            f"with type '{type}' and indicator '{indicator}'"
+        )
+
+        # Add temporary field to each TC to store list of archival objects refs
+        for tc in tcs:
+            tc_id = int(tc.get("uri", "0").split("/")[-1])
+            tc["ao_refs"] = get_ao_refs_for_top_container_from_db(db_config, tc_id)
+
+
+def main() -> None:
+    """Merge duplicate top containers in ArchivesSpace,
+    for a given resource (i.e. collection).
+
+    Summary of LSC ticket:
+    1. Retrieve all top containers in the collection.
+    2. Identify duplicate groups by type and indicator.
+    3. For each group, designate a canonical top container,
+      based on criteria provided by LSC.
+    4. Relink archival objects to the canonical top container.
+    5. Delete the duplicate top container(s).
+    """
+    configure_logging(Path(__file__).stem)
+    args = _get_args()
+    config = load_config(args.config_file)
+    db_config = config.get("database")
+    if not db_config:
+        raise ValueError("DB connection settings are required.")
+    aspace_client = ASnakeClient(**config)
+
+    _merge_duplicate_containers(aspace_client, db_config, args.resource_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -218,6 +218,7 @@ def _handle_duplicate_top_containers(
             )
 
             if original_ao != updated_ao:
+                print(updated_ao)
                 if dry_run:
                     logger.info(
                         f"DRY RUN: Would apply updates " f"to instance(s) on {ao_ref}"
@@ -266,7 +267,7 @@ def _merge_duplicate_containers(
         if len(tcs) > 1
     ]
     if not duplicate_groups:
-        logger.info("No duplicate top containers found for Resource ID {resource_id}.")
+        logger.info(f"No duplicate top containers found for Resource ID {resource_id}.")
         return
 
     for type, indicator, tcs in duplicate_groups:

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -75,11 +75,26 @@ def _get_tcs_by_indicator(
 def _determine_canonical_tc(tcs: list[dict]) -> tuple[dict, list[dict]]:
     """Determine the canonical top container from a list of top container records.
 
+    Uses the record with the most `ao_refs`,
+    or the oldest `create_time` if there are ties.
+
     :param list[dict] tcs: List of top container records.
     :return: A tuple of the canonical top container and the remaining duplicate TCs.
     """
-    sorted_by_ao_count = sorted(tcs, key=lambda tc: len(tc["ao_refs"]), reverse=True)
-    return sorted_by_ao_count[0], sorted_by_ao_count[1:]
+    # Had help from LLM for this concise implementation.
+    # Selects the minimum value of the tuple returned by the lambda function,
+    # which is the TC with the most `ao_refs` (i.e. smallest negative value)
+    # or the oldest `create_time` if there are ties in the AO counts.
+    canonical = min(
+        tcs,
+        key=lambda tc: (
+            -len(tc["ao_refs"]),
+            # If missing `create_time`,
+            # treat as in future so it sorts after TC with create time
+            tc.get("create_time", "9999-01-01T00:00:00Z"),
+        ),
+    )
+    return canonical, [tc for tc in tcs if tc is not canonical]
 
 
 def _update_archival_object(

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -58,7 +58,13 @@ def _get_tcs_by_indicator(
     db_config: dict,
     resource_id: int,
 ) -> defaultdict[tuple[str, str], list[dict]]:
-    """Get all top containers in the collection."""
+    """Get all top containers in the collection grouped by (type, indicator).
+
+    :param ASnakeClient aspace_client: An authenticated ASnakeClient instance.
+    :param dict db_config: DB connection settings.
+    :param int resource_id: The ID of the resource to process.
+    :return: A dictionary with (type, indicator) keys, and lists of top container records as values.
+    """
     container_refs = get_container_refs_from_db(db_config, resource_id)
     logger.info(
         f"Fetched {len(container_refs)} container{'s' if len(container_refs) > 1 else ''} "
@@ -81,7 +87,7 @@ def _get_tcs_by_indicator(
     return tcs_by_indicator
 
 
-def _resolve_ao_refs_for_tcs(
+def _resolve_aos_for_tcs(
     aspace_client: ASnakeClient, db_config: dict, tcs: list[dict]
 ) -> list[dict]:
     """Resolve archival object refs to archival object dicts for a list of top container records.
@@ -326,7 +332,7 @@ def _process_duplicates_in_collection(
         # Resolve AO refs to their full dictionaries
         # to make it easier to check AO titles for recent accession keywords
         # on the whole top container group at once.
-        tcs = _resolve_ao_refs_for_tcs(aspace_client, db_config, tcs)
+        tcs = _resolve_aos_for_tcs(aspace_client, db_config, tcs)
         # Check for recent accession keywords in the titles of related archival objects
         # in the duplicate group, and stop processing the group if any are found.
         if _has_recent_accession_keywords(tcs):

--- a/python/merge_duplicate_containers_aspace.py
+++ b/python/merge_duplicate_containers_aspace.py
@@ -122,6 +122,15 @@ def _relink_archival_objects(
     for duplicate_tc in duplicate_tcs:
         for ao_ref in duplicate_tc["ao_refs"]:
             archival_object = aspace_client.get(ao_ref).json()
+            title = archival_object.get("title", "")
+            # If any archival object in the group contains "backlog" or "accession" in its title,
+            # log a message and skip merging the duplicate group.
+            if ["backlog", "accession"] in title.lower():
+                logger.info(
+                    f"Found archival object indicating new accession or accrual: {ao_ref}."
+                    "Manual review required."
+                )
+                return
             original_instances = archival_object.get("instances", [])
             if not original_instances:
                 continue
@@ -166,8 +175,12 @@ def _merge_duplicate_containers(
             f"with type '{type}' and indicator '{indicator}'"
         )
 
-        # Add temporary field to each TC to store list of archival objects refs
+        # Add temporary field to each TC to store list of archival objects refs,
+        # and log locations if dry run
         for tc in tcs:
+            locations = tc.get("container_locations", [])
+            if dry_run and locations:
+                logger.info(f"Top container {tc.get('uri')} has locations: {locations}")
             tc_id = int(tc.get("uri", "0").split("/")[-1])
             tc["ao_refs"] = get_ao_refs_for_top_container_from_db(db_config, tc_id)
 

--- a/python/tests/test_merge_duplicate_containers_aspace.py
+++ b/python/tests/test_merge_duplicate_containers_aspace.py
@@ -1,0 +1,118 @@
+import unittest
+
+from merge_duplicate_containers_aspace import _determine_canonical_tc
+
+
+class TestMergeDuplicateContainers(unittest.TestCase):
+    """Tests for the `merge_duplicate_containers_aspace` module."""
+
+    def test_determine_canonical_tc_ao_count(self):
+        """Test that the canonical TC is the one with the most archival objects."""
+        # The first TC has 3 archival object refs,
+        # so it should be the canonical TC,
+        # even though it's the most recent.
+        test_tcs = [
+            {
+                "uri": "/top_containers/1",
+                "type": "box",
+                "indicator": "1",
+                "ao_refs": [
+                    "/archival_objects/1",
+                    "/archival_objects/2",
+                    "/archival_objects/3",
+                ],
+                "create_time": "2026-01-03T00:00:00Z",  # most recent
+            },
+            {
+                "uri": "/top_containers/2",
+                "type": "box",
+                "indicator": "1",
+                "ao_refs": ["/archival_objects/4", "/archival_objects/5"],
+                "create_time": "2026-01-02T00:00:00Z",
+            },
+            {
+                "uri": "/top_containers/3",
+                "type": "box",
+                "indicator": "1",
+                "ao_refs": ["/archival_objects/6"],
+                "create_time": "2026-01-01T00:00:00Z",
+            },
+        ]
+        canonical, duplicate_tcs = _determine_canonical_tc(test_tcs)
+        self.assertEqual(canonical, test_tcs[0])
+        self.assertEqual(duplicate_tcs, test_tcs[1:])
+
+    def test_determine_canonical_tc_create_time(self):
+        """Test that the canonical TC is the one with the oldest create time,
+        when there are ties in the number of archival objects.
+        """
+        # The first and second TCs have the same number of archival objects,
+        # but the second TC has the oldest create time,
+        # so it should be the canonical TC.
+        test_tcs = [
+            {
+                "uri": "/top_containers/1",
+                "type": "box",
+                "indicator": "1",
+                "ao_refs": [
+                    "/archival_objects/1",
+                    "/archival_objects/2",
+                ],
+                "create_time": "2026-01-03T00:00:00Z",
+            },
+            {
+                "uri": "/top_containers/2",
+                "type": "box",
+                "indicator": "1",
+                "ao_refs": ["/archival_objects/4", "/archival_objects/5"],
+                "create_time": "2026-01-01T00:00:00Z",  # oldest
+            },
+            {
+                "uri": "/top_containers/3",
+                "type": "box",
+                "indicator": "1",
+                "ao_refs": ["/archival_objects/6"],
+                "create_time": "2026-01-02T00:00:00Z",
+            },
+        ]
+        canonical, duplicate_tcs = _determine_canonical_tc(test_tcs)
+        self.assertEqual(canonical, test_tcs[1])
+        # Order should be 1, 0, 2 in this case
+        self.assertEqual(duplicate_tcs, [test_tcs[0], test_tcs[2]])
+
+    def test_determine_canonical_tc_missing_create_time(self):
+        """Test that the canonical TC is the one with the oldest create time,
+        when there are ties in the number of archival objects and create time is missing.
+        """
+        # The first and second TCs have the same number of archival objects,
+        # but the second TC is missing a create time,
+        # so the first should be the canonical TC.
+        test_tcs = [
+            {
+                "uri": "/top_containers/1",
+                "type": "box",
+                "indicator": "1",
+                "ao_refs": [
+                    "/archival_objects/1",
+                    "/archival_objects/2",
+                ],
+                "create_time": "2026-01-03T00:00:00Z",
+            },
+            {
+                "uri": "/top_containers/2",
+                "type": "box",
+                "indicator": "1",
+                "ao_refs": ["/archival_objects/4", "/archival_objects/5"],
+                # missing create time
+            },
+            {
+                "uri": "/top_containers/3",
+                "type": "box",
+                "indicator": "1",
+                "ao_refs": ["/archival_objects/6"],
+                "create_time": "2026-01-02T00:00:00Z",
+            },
+        ]
+        canonical, duplicate_tcs = _determine_canonical_tc(test_tcs)
+        self.assertEqual(canonical, test_tcs[0])
+        self.assertEqual(duplicate_tcs, test_tcs[1:])

--- a/python/tests/test_merge_duplicate_containers_aspace.py
+++ b/python/tests/test_merge_duplicate_containers_aspace.py
@@ -4,7 +4,7 @@ import unittest
 from asnake import logging
 from merge_duplicate_containers_aspace import (
     _determine_canonical_tc,
-    _check_for_location_data,
+    _has_location_data,
     _has_recent_accession_keywords,
 )
 
@@ -214,8 +214,10 @@ class TestMergeDuplicateContainers(unittest.TestCase):
         ]
 
         with capture_logs() as logs:
-            _check_for_location_data(test_tcs)
+            result = _has_location_data(test_tcs)
 
+        # Function should return True and log a warning message
+        self.assertTrue(result)
         # There should only be one log message,
         # since the second TC shouldn't generate one
         # because it has no location data.

--- a/python/tests/test_merge_duplicate_containers_aspace.py
+++ b/python/tests/test_merge_duplicate_containers_aspace.py
@@ -1,10 +1,26 @@
+import io
 import unittest
 
-from merge_duplicate_containers_aspace import _determine_canonical_tc
+from asnake import logging
+from merge_duplicate_containers_aspace import (
+    _determine_canonical_tc,
+    _check_for_location_data,
+    _has_recent_accession_keywords,
+)
+
+# Structlog comes with a context manager for capturing logs
+# before they hit the logging processors, making testing cleaner and easier.
+# See docs @https://www.structlog.org/en/stable/testing.html
+capture_logs = logging.structlog.testing.capture_logs
 
 
 class TestMergeDuplicateContainers(unittest.TestCase):
     """Tests for the `merge_duplicate_containers_aspace` module."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Log to in-memory buffer so no output to console or file
+        logging.setup_logging(stream=io.StringIO(), level="INFO")
 
     def test_determine_canonical_tc_ao_count(self):
         """Test that the canonical TC is the one with the most archival objects."""
@@ -16,10 +32,19 @@ class TestMergeDuplicateContainers(unittest.TestCase):
                 "uri": "/top_containers/1",
                 "type": "box",
                 "indicator": "1",
-                "ao_refs": [
-                    "/archival_objects/1",
-                    "/archival_objects/2",
-                    "/archival_objects/3",
+                "_related_aos_temp": [
+                    {
+                        "uri": "/archival_objects/1",
+                        "title": "Archival Object 1",
+                    },
+                    {
+                        "uri": "/archival_objects/2",
+                        "title": "Archival Object 2",
+                    },
+                    {
+                        "uri": "/archival_objects/3",
+                        "title": "Archival Object 3",
+                    },
                 ],
                 "create_time": "2026-01-03T00:00:00Z",  # most recent
             },
@@ -27,14 +52,28 @@ class TestMergeDuplicateContainers(unittest.TestCase):
                 "uri": "/top_containers/2",
                 "type": "box",
                 "indicator": "1",
-                "ao_refs": ["/archival_objects/4", "/archival_objects/5"],
+                "_related_aos_temp": [
+                    {
+                        "uri": "/archival_objects/4",
+                        "title": "Archival Object 4",
+                    },
+                    {
+                        "uri": "/archival_objects/5",
+                        "title": "Archival Object 5",
+                    },
+                ],
                 "create_time": "2026-01-02T00:00:00Z",
             },
             {
                 "uri": "/top_containers/3",
                 "type": "box",
                 "indicator": "1",
-                "ao_refs": ["/archival_objects/6"],
+                "_related_aos_temp": [
+                    {
+                        "uri": "/archival_objects/6",
+                        "title": "Archival Object 6",
+                    },
+                ],
                 "create_time": "2026-01-01T00:00:00Z",
             },
         ]
@@ -54,9 +93,15 @@ class TestMergeDuplicateContainers(unittest.TestCase):
                 "uri": "/top_containers/1",
                 "type": "box",
                 "indicator": "1",
-                "ao_refs": [
-                    "/archival_objects/1",
-                    "/archival_objects/2",
+                "_related_aos_temp": [
+                    {
+                        "uri": "/archival_objects/1",
+                        "title": "Archival Object 1",
+                    },
+                    {
+                        "uri": "/archival_objects/2",
+                        "title": "Archival Object 2",
+                    },
                 ],
                 "create_time": "2026-01-03T00:00:00Z",
             },
@@ -64,14 +109,28 @@ class TestMergeDuplicateContainers(unittest.TestCase):
                 "uri": "/top_containers/2",
                 "type": "box",
                 "indicator": "1",
-                "ao_refs": ["/archival_objects/4", "/archival_objects/5"],
+                "_related_aos_temp": [
+                    {
+                        "uri": "/archival_objects/4",
+                        "title": "Archival Object 4",
+                    },
+                    {
+                        "uri": "/archival_objects/5",
+                        "title": "Archival Object 5",
+                    },
+                ],
                 "create_time": "2026-01-01T00:00:00Z",  # oldest
             },
             {
                 "uri": "/top_containers/3",
                 "type": "box",
                 "indicator": "1",
-                "ao_refs": ["/archival_objects/6"],
+                "_related_aos_temp": [
+                    {
+                        "uri": "/archival_objects/6",
+                        "title": "Archival Object 6",
+                    },
+                ],
                 "create_time": "2026-01-02T00:00:00Z",
             },
         ]
@@ -92,9 +151,15 @@ class TestMergeDuplicateContainers(unittest.TestCase):
                 "uri": "/top_containers/1",
                 "type": "box",
                 "indicator": "1",
-                "ao_refs": [
-                    "/archival_objects/1",
-                    "/archival_objects/2",
+                "_related_aos_temp": [
+                    {
+                        "uri": "/archival_objects/1",
+                        "title": "Archival Object 1",
+                    },
+                    {
+                        "uri": "/archival_objects/2",
+                        "title": "Archival Object 2",
+                    },
                 ],
                 "create_time": "2026-01-03T00:00:00Z",
             },
@@ -102,17 +167,120 @@ class TestMergeDuplicateContainers(unittest.TestCase):
                 "uri": "/top_containers/2",
                 "type": "box",
                 "indicator": "1",
-                "ao_refs": ["/archival_objects/4", "/archival_objects/5"],
+                "_related_aos_temp": [
+                    {
+                        "uri": "/archival_objects/4",
+                        "title": "Archival Object 4",
+                    },
+                    {
+                        "uri": "/archival_objects/5",
+                        "title": "Archival Object 5",
+                    },
+                ],
                 # missing create time
             },
             {
                 "uri": "/top_containers/3",
                 "type": "box",
                 "indicator": "1",
-                "ao_refs": ["/archival_objects/6"],
+                "_related_aos_temp": [
+                    {
+                        "uri": "/archival_objects/6",
+                        "title": "Archival Object 6",
+                    },
+                ],
                 "create_time": "2026-01-02T00:00:00Z",
             },
         ]
         canonical, duplicate_tcs = _determine_canonical_tc(test_tcs)
         self.assertEqual(canonical, test_tcs[0])
         self.assertEqual(duplicate_tcs, test_tcs[1:])
+
+    def test_check_for_location_data(self):
+        """Test that location data is flagged for review in logs if found."""
+        test_tcs = [
+            {
+                "uri": "/top_containers/1",
+                "type": "box",
+                "indicator": "1",
+                "container_locations": ["location1", "location2"],
+            },
+            {
+                "uri": "/top_containers/2",
+                "type": "box",
+                "indicator": "1",
+                "container_locations": [],
+            },
+        ]
+
+        with capture_logs() as logs:
+            _check_for_location_data(test_tcs)
+
+        # There should only be one log message,
+        # since the second TC shouldn't generate one
+        # because it has no location data.
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(
+            logs[0]["event"],
+            "Top container /top_containers/1 has location data: ['location1', 'location2']",
+        )
+        self.assertEqual(logs[0]["log_level"], "warning")
+
+    def test_has_recent_accession_keywords(self):
+        """Test that `_has_recent_accession_keywords` returns True
+        and logs a warning message if recent accession keywords are found."""
+        test_tcs = [
+            {
+                "uri": "/top_containers/1",
+                "type": "box",
+                "indicator": "1",
+                "_related_aos_temp": [
+                    {
+                        "uri": "/archival_objects/1",
+                        "title": "Accession 1",
+                    },
+                    {
+                        "uri": "/archival_objects/2",
+                        "title": "Backlog 2",
+                    },
+                ],
+            },
+        ]
+
+        with capture_logs() as logs:
+            result = _has_recent_accession_keywords(test_tcs)
+
+        # Function should return True and log a warning message
+        self.assertTrue(result)
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(
+            logs[0]["event"],
+            "Archival object '/archival_objects/1' linked to top container '/top_containers/1' "
+            "may be recent accession: title='Accession 1'. "
+            "Manual review of duplicate group required.",
+        )
+        self.assertEqual(logs[0]["log_level"], "warning")
+
+    def test_has_recent_accession_keywords_no_keywords(self):
+        """Test that `_has_recent_accession_keywords` returns False
+        if no recent accession keywords are found."""
+        test_tcs = [
+            {
+                "uri": "/top_containers/1",
+                "type": "box",
+                "indicator": "1",
+                "_related_aos_temp": [
+                    {
+                        "uri": "/archival_objects/1",
+                        "title": "Archival Object 1",  # no recent accession keywords
+                    },
+                ],
+            },
+        ]
+
+        with capture_logs() as logs:
+            result = _has_recent_accession_keywords(test_tcs)
+
+        # Function should return False and log no messages
+        self.assertFalse(result)
+        self.assertEqual(len(logs), 0)

--- a/python/tests/test_merge_duplicate_containers_aspace.py
+++ b/python/tests/test_merge_duplicate_containers_aspace.py
@@ -203,7 +203,10 @@ class TestMergeDuplicateContainers(unittest.TestCase):
                 "uri": "/top_containers/1",
                 "type": "box",
                 "indicator": "1",
-                "container_locations": ["location1", "location2"],
+                "container_locations": [
+                    {"ref": "/locations/1"},
+                    {"ref": "/locations/2"},
+                ],
             },
             {
                 "uri": "/top_containers/2",
@@ -224,7 +227,7 @@ class TestMergeDuplicateContainers(unittest.TestCase):
         self.assertEqual(len(logs), 1)
         self.assertEqual(
             logs[0]["event"],
-            "Top container /top_containers/1 has location data: ['location1', 'location2']",
+            "Top container /top_containers/1 has location data: ['/locations/1', '/locations/2']",
         )
         self.assertEqual(logs[0]["log_level"], "warning")
 

--- a/python/tests/test_merge_duplicate_containers_aspace.py
+++ b/python/tests/test_merge_duplicate_containers_aspace.py
@@ -257,9 +257,7 @@ class TestMergeDuplicateContainers(unittest.TestCase):
         self.assertEqual(len(logs), 1)
         self.assertEqual(
             logs[0]["event"],
-            "Archival object '/archival_objects/1' linked to top container '/top_containers/1' "
-            "may be recent accession: title='Accession 1'. "
-            "Manual review of duplicate group required.",
+            "Manual review required",
         )
         self.assertEqual(logs[0]["log_level"], "warning")
 

--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -6,6 +6,7 @@ E.g. `from utils import configure_logging` vs `from utils.generic_utils import c
 
 from .generic_utils import (
     configure_logging,
+    configure_console_logging,
     load_config,
     write_dicts_to_csv,
     read_from_cache,
@@ -14,6 +15,7 @@ from .generic_utils import (
 
 __all__ = [
     "configure_logging",
+    "configure_console_logging",
     "load_config",
     "write_dicts_to_csv",
     "read_from_cache",

--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -6,7 +6,6 @@ E.g. `from utils import configure_logging` vs `from utils.generic_utils import c
 
 from .generic_utils import (
     configure_logging,
-    configure_console_logging,
     load_config,
     write_dicts_to_csv,
     read_from_cache,
@@ -15,7 +14,6 @@ from .generic_utils import (
 
 __all__ = [
     "configure_logging",
-    "configure_console_logging",
     "load_config",
     "write_dicts_to_csv",
     "read_from_cache",

--- a/python/utils/generic_utils.py
+++ b/python/utils/generic_utils.py
@@ -9,29 +9,30 @@ from datetime import datetime
 from pathlib import Path
 
 
-def configure_console_logging() -> None:
-    """Configure ASnake logging to output to the console.
-
-    The ASnake logging module uses structlog,
-    which provides a console logger for development.
-    See docs @https://www.structlog.org/en/stable/console-output.html
-    """
-    processors = logging.default_structlog_conf()["processors"]
-    processors[-1] = logging.structlog.dev.ConsoleRenderer()
-    logging.structlog.configure(processors=processors)
-
-
-def configure_logging(log_filename_stem: str = "log") -> None:
+def configure_logging(
+    log_filename_stem: str = "log",
+    dry_run: bool = False,
+) -> None:
     """Configure ASnake logging using the provided log filename stem.
 
     :param str log_filename_stem: The filename stem to use for the configured log file.
         Defaults to "log".
+    :param bool dry_run: If True, write human-readable lines for review.
+        If False, use ASnake's default JSON line format. Defaults to False.
     """
     logs_dir = Path("logs")  # save logs to "./logs/"
     logs_dir.mkdir(parents=True, exist_ok=True)  # create dir if it doesn't exist
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     log_filename = logs_dir / f"{log_filename_stem}_{timestamp}.log"
     logging.setup_logging(filename=log_filename, level="INFO")
+    if dry_run:
+        # The `asnake.logging` module uses `structlog`,
+        # which provides a pretty-print console logger called `ConsoleRenderer`.
+        # Using that here for a more human-readable format in dry run mode.
+        # See docs @https://www.structlog.org/en/stable/console-output.html
+        processors = logging.default_structlog_conf()["processors"]
+        processors[-1] = logging.structlog.dev.ConsoleRenderer(colors=False)
+        logging.structlog.configure(processors=processors)
 
 
 def load_config(config_file: str) -> dict:

--- a/python/utils/generic_utils.py
+++ b/python/utils/generic_utils.py
@@ -1,11 +1,24 @@
 """Generic utility functions for reuse across scripts."""
 
-import asnake.logging as logging
 import csv
 import json
 import yaml
+
+from asnake import logging
 from datetime import datetime
 from pathlib import Path
+
+
+def configure_console_logging() -> None:
+    """Configure ASnake logging to output to the console.
+
+    The ASnake logging module uses structlog,
+    which provides a console logger for development.
+    See docs @https://www.structlog.org/en/stable/console-output.html
+    """
+    processors = logging.default_structlog_conf()["processors"]
+    processors[-1] = logging.structlog.dev.ConsoleRenderer()
+    logging.structlog.configure(processors=processors)
 
 
 def configure_logging(log_filename_stem: str = "log") -> None:

--- a/python/utils/generic_utils.py
+++ b/python/utils/generic_utils.py
@@ -24,15 +24,29 @@ def configure_logging(
     logs_dir.mkdir(parents=True, exist_ok=True)  # create dir if it doesn't exist
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     log_filename = logs_dir / f"{log_filename_stem}_{timestamp}.log"
+
     logging.setup_logging(filename=log_filename, level="INFO")
+
+    # structlog's TimeStamper defaults to UTC, but we want the system's local time.
+    # The default config has a list of processors that includes a TimeStamper,
+    # so we need to find that and replace it with our own,
+    # with `utc=False` to use the system timezone.
+    processors = logging.default_structlog_conf()["processors"]
+    processors = [
+        (
+            logging.structlog.processors.TimeStamper(fmt="iso", utc=False)
+            if isinstance(processor, logging.structlog.processors.TimeStamper)
+            else processor
+        )
+        for processor in processors
+    ]
+    # For more human-readable output in dry run mode,
+    # replace the `JSONRenderer` with a `ConsoleRenderer`
+    # in structlog's processor list.
+    # See docs @https://www.structlog.org/en/stable/console-output.html
     if dry_run:
-        # The `asnake.logging` module uses `structlog`,
-        # which provides a pretty-print console logger called `ConsoleRenderer`.
-        # Using that here for a more human-readable format in dry run mode.
-        # See docs @https://www.structlog.org/en/stable/console-output.html
-        processors = logging.default_structlog_conf()["processors"]
         processors[-1] = logging.structlog.dev.ConsoleRenderer(colors=False)
-        logging.structlog.configure(processors=processors)
+    logging.structlog.configure(processors=processors)
 
 
 def load_config(config_file: str) -> dict:

--- a/python/utils/generic_utils.py
+++ b/python/utils/generic_utils.py
@@ -12,13 +12,14 @@ from pathlib import Path
 def configure_logging(
     log_filename_stem: str = "log",
     dry_run: bool = False,
-) -> None:
+) -> str:
     """Configure ASnake logging using the provided log filename stem.
 
     :param str log_filename_stem: The filename stem to use for the configured log file.
         Defaults to "log".
     :param bool dry_run: If True, write human-readable lines for review.
         If False, use ASnake's default JSON line format. Defaults to False.
+    :return str: The name of the log file.
     """
     logs_dir = Path("logs")  # save logs to "./logs/"
     logs_dir.mkdir(parents=True, exist_ok=True)  # create dir if it doesn't exist
@@ -47,6 +48,8 @@ def configure_logging(
     if dry_run:
         processors[-1] = logging.structlog.dev.ConsoleRenderer(colors=False)
     logging.structlog.configure(processors=processors)
+
+    return log_filename.name
 
 
 def load_config(config_file: str) -> dict:


### PR DESCRIPTION
Implements [DLSR-260](https://uclalibrary.atlassian.net/browse/DLSR-260)

### Acceptance criteria
- [x] No archival objects lose container links as a result of the merge
- [X] Each collection contains at most one top container per unique container type + indicator combination after processing
- [x] Container profiles, barcodes, and Instance types are preserved on the canonical container
- [X] Duplicate container records no longer exist after processing
- [X] A log or summary is produced identifying which containers were merged with any errors documented

### Description
This PR adds `merge_duplicate_containers_aspace.py`, which finds and merges duplicate top containers within a single ASpace collection. After fetching top container records, the script groups duplicates using a `(type, indicator)` tuple as group keys. From these groups, canonical top containers are identified per LSC specs: either the one with the most linked archival objects, or the oldest `create_time` in the case of ties.

One thing this script does differently than `cleanup_compound_indicators_aspace.py` is it merges duplicates using the ArchivesSpace `/merge_requests/top_container` API endpoint, rather than manual AO relinking. I had overlooked this endpoint in earlier review of the ASpace docs (which to be fair is not the clearest...); relevant documentation is [here](https://archivesspace.github.io/archivesspace/api/?python#carry-out-a-merge-request-against-top-container-records). From manual testing using some scratch scripts, this endpoint appears to do everything LSC requested when consolidating top container records: identify target top container and sources, re-link all related archival objects from sources to target, then delete the sources.

The script has a dry-run mode that outputs slightly different information in a more human-readable format than the normal mode. This is intended to make manual review of the logs easier on LSC. Please let me know if you have thoughts on how to improve the clarity of the log messages or summary.

### Testing
Unit tests are added for the canonical selection logic, location-data warnings, and accession-keyword detection. There are now 22 tests for the toolkit.

As for manual testing, resource `3646` is a good illustration. There should be 54 containers before merging 13 duplicate groups, and 16 top containers after: `python merge_duplicate_containers_aspace.py -c .archivessnake_secret_DEV.yml -r 3646 -d` for dry run; `-d` can be removed for normal mode.

#### Demo gist
I created this (kind of messy) [Gist](https://gist.github.com/henry-r18/c4697f484c08147f2613cb58ea52ed0f) to demonstrate that the function that uses the `merge_requests/top_container` endpoint behaves as desired by LSC. The Gist will run "live", meaning it will actually merge the resource ID provided as a illustration in your local ASpace instance, so be warned. I picked that collection (i.e. resource ID) because it has several duplicate groups and gives a good demonstration that the endpoint manages relinked AOs from duplicates to the canonical TC and then deletes the duplicates.

I can provide a list of other good collections to test, if desired.

[DLSR-260]: https://uclalibrary.atlassian.net/browse/DLSR-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ