### PR TITLE
DLSR-524: use consistent output directories for aspace scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ docker compose exec python python add_alma_barcodes_to_archivesspace.py \
     --bib_id 123456789 \
     --holdings_id 987654321 \
     --resource_id 1234 \
-    --profile config.indicator_type_matching.py \
+    --profile config.indicator_type_matching \
     --config_file .archivessnake_secret_DEV.yml \
     --dry_run \
     --use_cache \
@@ -185,10 +185,10 @@ We have only barcoded a few collections so far, so the profiles may need to be a
 ### Evaluating the script output
 
 After running the script, you will see several output files:
-- `add_alma_barcodes_to_archivesspace_{timestamp}.log`: The main log file.
-- `unhandled_add_alma_barcodes_to_archivesspace_{timestamp}.json`: A JSON file containing Alma items that were not matched to ArchivesSpace top containers.
-- `aspace_data_{resource_id}.json`: A JSON file containing the ArchivesSpace top container data for the resource. This file is used as a data source for the script if the `--use_cache` flag is set.
-- `alma_data_{bib_id}_{holdings_id}.json`: A JSON file containing the Alma item data for the collection. This file is used as a data source for the script if the `--use_cache` flag is set.
+- `/logs/add_alma_barcodes_to_archivesspace_{timestamp}.log`: The main log file.
+- `/output/unhandled_add_alma_barcodes_to_archivesspace.json`: A JSON file containing Alma items that were not matched to ArchivesSpace top containers.
+- `/output/aspace_data_{resource_id}.json`: A JSON file containing the ArchivesSpace top container data for the resource. This file is used as a data source for the script if the `--use_cache` flag is set.
+- `/output/alma_data_{holdings_id}.json`: A JSON file containing the Alma item data for the collection. This file is used as a data source for the script if the `--use_cache` flag is set.
 
 The first two of these files are important for evaluating the script output. The log file ends with a summary statement describing the total number of Alma and ArchivesSpace records processed, the number of matches and non-matches, and the number of items with duplicate keys. If more than 80% of the items from each source are matched, the configuration profile is likely correct and the data is clean enough to run the script in the production environment.
 
@@ -203,7 +203,7 @@ The unhandled items file contains five types of potential issues:
 
 UCLA has two hosted ArchivesSpace instances: test (https://uclalsc-test.lyrasistechnology.org/) and production (https://uclalsc-staff.lyrasistechnology.org/). 
 
-To use the script to update barcodes in the test or production ArchivesSpace instances, run the script from the support server, `p-u-exlsupport01.library.ucla.edu`, with the appropriate configuration file: `.archivessnake_secret_TEST.yml` for test and `.archivessnake_secret_PROD.yml` for production. Unlike the local setup, the script runs directly on the support server, not in a Docker container.
+To use the script to update barcodes in the test or production ArchivesSpace instances, run it from the support server, `p-u-asrunner01.library.ucla.edu`, using `run_aspace_script.sh`, with the appropriate configuration file: `.archivessnake_secret_TEST.yml` for test and `.archivessnake_secret_PROD.yml` for production. As with the local setup, logs and reports are written to `/logs` and `/output` inside the container.
 Ask a teammate if you need help accessing the support server. 
 
 Alternatively, you can run the script against the test instance from your local machine by setting up a tunneled connection. See the "Connecting to remote instances (UCLA only)" section below for more information. You will need to create a new API configuration file (copy of `.archivessnake.yml`), with an updated `baseurl` of `https://uclalsc-test.lyrasistechnology.org:9000/api` and other credentials as appropriate - ask a teammate if you need these.
@@ -225,7 +225,7 @@ The `add_alma_barcodes_to_archivesspace.py` script includes a utility which can 
 To "undo" barcodes recorded in a log file, use the following CLI flags as additional arguments for a typical command, as described above under *Example Usage*:
 
 1. `--undo_barcoding`: activates the utility
-2. `--use_log` {LOG_FILENAME}: provides the filename for the relevant log file, which should include event messages in the format "Added barcode to top container {TOP_CONTAINER_REF}"
+2. `--use_log` {LOG_PATH}: provides the path to the relevant log file (e.g. `/logs/add_alma_barcodes_to_archivesspace_{timestamp}.log`), which should include event messages in the format "Added barcode to top container {TOP_CONTAINER_REF}"
 
 Note that `--use_log` cannot be used without `--undo_barcoding`. However, if `--undo_barcoding` is used without `--use_log`, the utility will prompt twice for confirmation before deleting all barcodes related to the provided `resource_id`.
 
@@ -282,8 +282,8 @@ This script uses the same matching profiles as the barcoding script. See [Config
 ### Evaluating the script output
 After running the script, you will see the following output files:
 
-- `logs/migrate_alma_metadata_to_archivesspace_{timestamp}.log`: The main log file, ending with a summary of totals, matches, and skipped items.
-- `unhandled_migrate_alma_metadata_to_archivesspace.json`: A JSON file containing any unmatched or duplicate items. Contains the same categories as the barcoding script's unhandled output, except `top_containers_with_barcode` (not applicable here).
+- `/logs/migrate_alma_metadata_to_archivesspace_{timestamp}.log`: The main log file, ending with a summary of totals, matches, and skipped items.
+- `/output/unhandled_migrate_alma_metadata_to_archivesspace.json`: A JSON file containing any unmatched or duplicate items. Contains the same categories as the barcoding script's unhandled output, except `top_containers_with_barcode` (not applicable here).
 
 The log summary also includes counts of containers skipped for location update (non-SRLF items) and container profile update (missing or unrecognized VolEquiv).
 
@@ -335,4 +335,3 @@ ssh -i ~/.ssh/id_aspace_ssh -NT -L \
 ucla-kohler@aspace-hosting-production-bastion.lyrtech.org
 ```
 This tunnel runs in the foreground, so you'll need to open a second connection to run programs which need it.
-

--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ We have only barcoded a few collections so far, so the profiles may need to be a
 ### Evaluating the script output
 
 After running the script, you will see several output files:
-- `/logs/add_alma_barcodes_to_archivesspace_{timestamp}.log`: The main log file.
-- `/output/unhandled_add_alma_barcodes_to_archivesspace.json`: A JSON file containing Alma items that were not matched to ArchivesSpace top containers.
-- `/output/aspace_data_{resource_id}.json`: A JSON file containing the ArchivesSpace top container data for the resource. This file is used as a data source for the script if the `--use_cache` flag is set.
-- `/output/alma_data_{holdings_id}.json`: A JSON file containing the Alma item data for the collection. This file is used as a data source for the script if the `--use_cache` flag is set.
+- `logs/add_alma_barcodes_to_archivesspace_{timestamp}.log`: The main log file.
+- `output/unhandled_add_alma_barcodes_to_archivesspace.json`: A JSON file containing Alma items that were not matched to ArchivesSpace top containers.
+- `output/aspace_data_{resource_id}.json`: A JSON file containing the ArchivesSpace top container data for the resource. This file is used as a data source for the script if the `--use_cache` flag is set.
+- `output/alma_data_{holdings_id}.json`: A JSON file containing the Alma item data for the collection. This file is used as a data source for the script if the `--use_cache` flag is set.
 
 The first two of these files are important for evaluating the script output. The log file ends with a summary statement describing the total number of Alma and ArchivesSpace records processed, the number of matches and non-matches, and the number of items with duplicate keys. If more than 80% of the items from each source are matched, the configuration profile is likely correct and the data is clean enough to run the script in the production environment.
 
@@ -203,7 +203,7 @@ The unhandled items file contains five types of potential issues:
 
 UCLA has two hosted ArchivesSpace instances: test (https://uclalsc-test.lyrasistechnology.org/) and production (https://uclalsc-staff.lyrasistechnology.org/). 
 
-To use the script to update barcodes in the test or production ArchivesSpace instances, run it from the support server, `p-u-asrunner01.library.ucla.edu`, using `run_aspace_script.sh`, with the appropriate configuration file: `.archivessnake_secret_TEST.yml` for test and `.archivessnake_secret_PROD.yml` for production. As with the local setup, logs and reports are written to `/logs` and `/output` inside the container.
+To use the script to update barcodes in the test or production ArchivesSpace instances, run it from the support server, `p-u-asrunner01.library.ucla.edu`, using the toolkit's Docker image, with the appropriate configuration file: `.archivessnake_secret_TEST.yml` for test and `.archivessnake_secret_PROD.yml` for production. As with the local setup, logs and reports are written to `logs/` and `output/`, relative to the container's working directory.
 Ask a teammate if you need help accessing the support server. 
 
 Alternatively, you can run the script against the test instance from your local machine by setting up a tunneled connection. See the "Connecting to remote instances (UCLA only)" section below for more information. You will need to create a new API configuration file (copy of `.archivessnake.yml`), with an updated `baseurl` of `https://uclalsc-test.lyrasistechnology.org:9000/api` and other credentials as appropriate - ask a teammate if you need these.
@@ -225,7 +225,7 @@ The `add_alma_barcodes_to_archivesspace.py` script includes a utility which can 
 To "undo" barcodes recorded in a log file, use the following CLI flags as additional arguments for a typical command, as described above under *Example Usage*:
 
 1. `--undo_barcoding`: activates the utility
-2. `--use_log` {LOG_PATH}: provides the path to the relevant log file (e.g. `/logs/add_alma_barcodes_to_archivesspace_{timestamp}.log`), which should include event messages in the format "Added barcode to top container {TOP_CONTAINER_REF}"
+2. `--use_log` {LOG_PATH}: provides the path to the relevant log file (e.g. `logs/add_alma_barcodes_to_archivesspace_{timestamp}.log`), which should include event messages in the format "Added barcode to top container {TOP_CONTAINER_REF}"
 
 Note that `--use_log` cannot be used without `--undo_barcoding`. However, if `--undo_barcoding` is used without `--use_log`, the utility will prompt twice for confirmation before deleting all barcodes related to the provided `resource_id`.
 
@@ -282,8 +282,8 @@ This script uses the same matching profiles as the barcoding script. See [Config
 ### Evaluating the script output
 After running the script, you will see the following output files:
 
-- `/logs/migrate_alma_metadata_to_archivesspace_{timestamp}.log`: The main log file, ending with a summary of totals, matches, and skipped items.
-- `/output/unhandled_migrate_alma_metadata_to_archivesspace.json`: A JSON file containing any unmatched or duplicate items. Contains the same categories as the barcoding script's unhandled output, except `top_containers_with_barcode` (not applicable here).
+- `logs/migrate_alma_metadata_to_archivesspace_{timestamp}.log`: The main log file, ending with a summary of totals, matches, and skipped items.
+- `output/unhandled_migrate_alma_metadata_to_archivesspace.json`: A JSON file containing any unmatched or duplicate items. Contains the same categories as the barcoding script's unhandled output, except `top_containers_with_barcode` (not applicable here).
 
 The log summary also includes counts of containers skipped for location update (non-SRLF items) and container profile update (missing or unrecognized VolEquiv).
 

--- a/python/find_missing_containers_aspace.py
+++ b/python/find_missing_containers_aspace.py
@@ -67,7 +67,7 @@ def _get_args() -> argparse.Namespace:
             ".csv"
         ),
         help=(
-            "Filename for the CSV report (written under the shared /output "
+            "Filename for the CSV report (written under the shared output/ "
             "directory; any path component is ignored). "
             "Defaults to 'aspace_missing_containers_<DATETIME>.csv'."
         ),

--- a/python/find_missing_containers_aspace.py
+++ b/python/find_missing_containers_aspace.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 from alma_api_client import AlmaAPIClient
 from asnake.client import ASnakeClient
-from pathlib import Path
 
 from utils import load_config, write_dicts_to_csv
 from utils.alma_utils import get_alma_items_from_alma
@@ -63,13 +62,14 @@ def _get_args() -> argparse.Namespace:
         type=str,
         required=False,
         default=(
-            f"reports/aspace_missing_containers_"
+            f"aspace_missing_containers_"
             f"{datetime.now().strftime('%Y%m%d_%H%M%S')}"
             ".csv"
         ),
         help=(
-            "Path to write the CSV report. "
-            "Defaults to 'reports/aspace_missing_containers_<DATETIME>.csv'."
+            "Filename for the CSV report (written under the shared /output "
+            "directory; any path component is ignored). "
+            "Defaults to 'aspace_missing_containers_<DATETIME>.csv'."
         ),
     )
     return parser.parse_args()
@@ -224,7 +224,6 @@ def main() -> None:
     )
 
     # Write the CSV report
-    print(f"Writing CSV report to {args.output_path}")
     rows = _prepare_report_rows(
         unmatched_alma_items,
         args.bib_id,
@@ -232,8 +231,8 @@ def main() -> None:
         aspace_resource_id_human_readable,
         aspace_resource_title,
     )
-    output_path = Path(args.output_path)
-    write_dicts_to_csv(output_path, rows)
+    resolved_output_path = write_dicts_to_csv(args.output_path, rows)
+    print(f"CSV report written to {resolved_output_path}")
 
 
 if __name__ == "__main__":

--- a/python/get_container_counts.py
+++ b/python/get_container_counts.py
@@ -68,8 +68,8 @@ def main() -> None:
     print(f"{rows_updated_with_counts} of {total_rows} rows were updated with counts.")
 
     output_filename = Path(args.file_name).stem + "_with_container_counts.csv"
-    print(f"Writing counts to {output_filename}...")
-    write_dicts_to_csv(Path(output_filename), data_with_counts)
+    resolved_output_path = write_dicts_to_csv(output_filename, data_with_counts)
+    print(f"Counts written to {resolved_output_path}")
 
 
 if __name__ == "__main__":

--- a/python/get_unlinked_top_containers.py
+++ b/python/get_unlinked_top_containers.py
@@ -4,6 +4,7 @@ import asnake.logging as logging
 from asnake.client import ASnakeClient
 from pathlib import Path
 from utils import configure_logging, load_config
+from utils.generic_utils import resolve_output_path
 
 # Logger available globally within this module.
 # Configuration is done by configure_logging(), which is called by main().
@@ -33,7 +34,11 @@ def _get_args() -> argparse.Namespace:
     parser.add_argument(
         "-o",
         "--output_file",
-        help="Path to a file to write the output to. Defaults to unlinked_top_containers.txt.",
+        help=(
+            "Filename to write the output to (written under the shared /output "
+            "directory; any path component is ignored). Defaults to "
+            "unlinked_top_containers.txt."
+        ),
         required=False,
         default="unlinked_top_containers.txt",
     )
@@ -67,10 +72,11 @@ def get_unlinked_top_containers(
             output_list.append(top_container["uri"])
 
     logger.info(f"Total unlinked top containers: {len(output_list)}")
-    with open(output_file, "w") as f:
+    resolved_output_file = resolve_output_path(output_file)
+    with open(resolved_output_file, "w") as f:
         for item in output_list:
             f.write(f"{item}\n")
-    logger.info(f"Output written to {output_file}")
+    logger.info(f"Output written to {resolved_output_file}")
 
 
 def main() -> None:

--- a/python/get_unlinked_top_containers.py
+++ b/python/get_unlinked_top_containers.py
@@ -35,8 +35,8 @@ def _get_args() -> argparse.Namespace:
         "-o",
         "--output_file",
         help=(
-            "Filename to write the output to (written under the shared /output "
-            "directory; any path component is ignored). Defaults to "
+            "Filename to write the output to (written under the shared "
+            "output/ directory; any path component is ignored). Defaults to "
             "unlinked_top_containers.txt."
         ),
         required=False,

--- a/python/utils/generic_utils.py
+++ b/python/utils/generic_utils.py
@@ -8,6 +8,25 @@ from asnake import logging
 from datetime import datetime
 from pathlib import Path
 
+# Shared output directories. These are expected to be mounted as volumes
+# (e.g. via `docker compose`) so that logs, reports, and cache files land
+# in predictable, host-accessible locations regardless of which script
+# or container produced them.
+LOGS_DIR = Path("/logs")
+OUTPUT_DIR = Path("/output")
+
+
+def resolve_output_path(filename: str | Path) -> Path:
+    """Resolve a filename to a path under the shared OUTPUT_DIR, creating
+    the directory if needed.
+
+    :param str | Path filename: A filename, or a path whose filename
+        component should be resolved under OUTPUT_DIR.
+    :return Path: The resolved path under OUTPUT_DIR.
+    """
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    return OUTPUT_DIR / Path(filename).name
+
 
 def configure_logging(
     log_filename_stem: str = "log",
@@ -21,10 +40,9 @@ def configure_logging(
         If False, use ASnake's default JSON line format. Defaults to False.
     :return str: The name of the log file.
     """
-    logs_dir = Path("logs")  # save logs to "./logs/"
-    logs_dir.mkdir(parents=True, exist_ok=True)  # create dir if it doesn't exist
+    LOGS_DIR.mkdir(parents=True, exist_ok=True)  # create dir if it doesn't exist
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    log_filename = logs_dir / f"{log_filename_stem}_{timestamp}.log"
+    log_filename = LOGS_DIR / f"{log_filename_stem}_{timestamp}.log"
 
     logging.setup_logging(filename=log_filename, level="INFO")
 
@@ -63,34 +81,38 @@ def load_config(config_file: str) -> dict:
 
 
 def write_dicts_to_csv(
-    output_path: Path,
+    output_path: str | Path,
     rows: list[dict],
-) -> None:
-    """Write a list of dictionaries to a CSV file,
+) -> Path:
+    """Write a list of dictionaries to a CSV file under the shared OUTPUT_DIR,
     with each dict representing a row in the CSV.
     Fieldnames are derived from the first dict in the list.
 
-    :param Path output_path: Path to write the CSV file.
+    :param str | Path output_path: Filename (or path) for the CSV file. Only the
+        filename component is used — the file is always written under OUTPUT_DIR.
     :param list[dict] rows: A list of CSV row dictionaries.
+    :return Path: The resolved path the CSV was written to.
     """
+    resolved_path = resolve_output_path(output_path)
     # Get the fieldnames from the first row
     fieldnames = list(rows[0].keys())
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w", newline="", encoding="utf-8") as f:
+    with open(resolved_path, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(rows)
+    return resolved_path
 
 
 def read_from_cache(filename: str) -> list[dict] | None:
-    """Reads data from the given file and returns it.
+    """Reads data from the given file (under the shared OUTPUT_DIR) and returns it.
     Data is expected to be a list of dictionaries,
     but this method does not enforce that.
 
-    :param str filename: Filename of cache file.
+    :param str filename: Filename of cache file. Only the filename component
+        is used — the file is always read from OUTPUT_DIR.
     :return: A list of dictionaries, or None if the cache file does not exist.
     """
-    data_file = Path(filename)
+    data_file = resolve_output_path(filename)
     if data_file.exists():
         with open(data_file, "r") as f:
             data = json.load(f)
@@ -103,15 +125,19 @@ def write_to_cache(
     data: dict | list[dict],
     filename: str,
     indent: int | None = None,
-) -> None:
-    """Stores data in the given file for possible later use.
+) -> Path:
+    """Stores data in the given file (under the shared OUTPUT_DIR) for possible later use.
     Data is expected to be a dict or list of dicts,
     but this method does not enforce that.
 
     :param dict | list[dict] data: Data to write to the cache file.
-    :param str filename: Filename for cache file.
+    :param str filename: Filename for cache file. Only the filename component
+        is used — the file is always written under OUTPUT_DIR.
     :param int indent: Number of spaces to indent the JSON data.
         Defaults to None, which means no indentation.
+    :return Path: The resolved path the cache file was written to.
     """
-    with open(filename, "w") as f:
+    resolved_path = resolve_output_path(filename)
+    with open(resolved_path, "w") as f:
         json.dump(data, f, indent=indent)
+    return resolved_path

--- a/python/utils/generic_utils.py
+++ b/python/utils/generic_utils.py
@@ -8,17 +8,23 @@ from asnake import logging
 from datetime import datetime
 from pathlib import Path
 
-# Shared output directories. These are expected to be mounted as volumes
-# (e.g. via `docker compose`) so that logs, reports, and cache files land
-# in predictable, host-accessible locations regardless of which script
-# or container produced them.
-LOGS_DIR = Path("/logs")
-OUTPUT_DIR = Path("/output")
+# Shared output directories, relative to the current working directory
+# (the script's launch directory — WORKDIR inside the toolkit's containers).
+# These are expected to be mounted as volumes (e.g. via `docker compose`)
+# so that logs, reports, and cache files land in predictable,
+# host-accessible locations regardless of which script produced them.
+LOGS_DIR = Path("logs")
+OUTPUT_DIR = Path("output")
 
 
 def resolve_output_path(filename: str | Path) -> Path:
     """Resolve a filename to a path under the shared OUTPUT_DIR, creating
     the directory if needed.
+
+    Only the filename component of `filename` is used — any directory
+    part supplied by a caller (e.g. a `reports/` prefix or a path from a
+    CLI arg) is discarded, so that all script output consistently lands
+    in OUTPUT_DIR regardless of how it's invoked.
 
     :param str | Path filename: A filename, or a path whose filename
         component should be resolved under OUTPUT_DIR.


### PR DESCRIPTION
Implements [DLSR-524](https://uclalibrary.atlassian.net/browse/DLSR-524)

This should be merged before (or simultaneously with) https://github.com/UCLALibrary/archivesspace-toolkit/pull/31 ([DLSR-488](https://uclalibrary.atlassian.net/browse/DLSR-488))

Updates all Python scripts in this repo to consistently use two directories for output: `\logs` (for .log files) and `\output` (for everything else, currently JSON/txt reports and data cache files).

The bulk of the change is in `utils/generic_utils.py`. This file now defines `OUTPUT_DIR` and `LOGS_DIR`, and methods that write output now use these values as destination folders. Since most scripts in this repo import their output methods from this utils module, this fixed the majority of the scripts.

Only three scripts needed actual updates:
* `find_missing_containers_aspace.py`: updated default path, removed redundant `Path()` casting, and fixed info in print statements.
* `get_unlinked_top_containers.py`: as before, this script writes its own CSV without importing from `utils`. It now uses the new `resolve_output_path` to determine its destination.
* `get_container_counts.py`: removed redundant `Path()` casting, and fixed print statement.

The README is also updated in a few places to reflect the changed output destinations, and to fix an unrelated incorrect sample command.

[DLSR-524]: https://uclalibrary.atlassian.net/browse/DLSR-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DLSR-488]: https://uclalibrary.atlassian.net/browse/DLSR-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ